### PR TITLE
Fix factor coercion error

### DIFF
--- a/R/estimateCellCounts2.R
+++ b/R/estimateCellCounts2.R
@@ -421,11 +421,9 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
         rgSet$Sex<-rep("NA", dim(rgSet)[2])
     commoncolumn<-intersect(names(colData(rgSet)), 
                             names(colData(referenceRGset)))
-    colData(referenceRGset)[commoncolumn] <- mapply(FUN = as,
-                                        colData(referenceRGset)[commoncolumn],
-                                        vapply(colData(rgSet)[commoncolumn],
-                                                class, FUN.VALUE=character(1)),
-                                                    SIMPLIFY = FALSE)
+    colData(referenceRGset)[commoncolumn] <- mapply(FUN = function(object, Class) eval(str2lang(paste0("as.", Class, "(object)"))), 
+                                                colData(referenceRGset)[commoncolumn], vapply(colData(rgSet)[commoncolumn], 
+                                                                                              class, FUN.VALUE = character(1)), SIMPLIFY = FALSE)
     colData(referenceRGset)<-colData(referenceRGset)[commoncolumn]
     colData(rgSet)<-colData(rgSet)[commoncolumn]
     referencePd <- colData(referenceRGset)


### PR DESCRIPTION
I encountered an error when using RGsets with factor columns in their colData:

Error in (function (object, Class, strict = TRUE, ext = possibleExtends(thisClass,  : 
no method or default for coercing "character" to "factor"

This improvised modification prevents that error.