### PR TITLE
Fix default platform for CordBloodCombined

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FlowSorted.Blood.EPIC
 Type: Package
 Title: Illumina EPIC data on immunomagnetic sorted peripheral adult blood cells
-Version: 1.7.1
-Date: 2020-05-10
+Version: 1.11.0
+Date: 2020-14-04
 Authors@R: c( person(c("Lucas", "A."), "Salas", role = c("cre", "aut"),
             email = "lucas.a.salas.diaz@dartmouth.edu"),
             person(c("Devin", "C."), "Koestler", role = c("aut"),
@@ -44,6 +44,6 @@ Suggests: knitr,
     IlluminaHumanMethylation450kanno.ilmn12.hg19(>= 0.2.1), 
     IlluminaHumanMethylationEPICanno.ilm10b2.hg19
 VignetteBuilder: knitr
-RoxygenNote: 7.1.0
+RoxygenNote: 7.0.2
 URL: https://github.com/immunomethylomics/FlowSorted.Blood.EPIC
 BugReports: https://github.com/immunomethylomics/FlowSorted.Blood.EPIC/issues.

--- a/R/FlowSorted.Blood.EPIC.R
+++ b/R/FlowSorted.Blood.EPIC.R
@@ -3,10 +3,9 @@
 #' Illumina Human Methylation data from EPIC on immunomagnetic sorted adult 
 #' blood cell populations. The FlowSorted.Blood.EPIC package contains Illumina
 #' HumanMethylationEPIC (\dQuote{EPIC})) DNA methylation microarray data
-#' from the immunomethylomics group  
-#' \href{https://dx.doi.org/10.1186/s13059-018-1448-7}{(Salas et al. 2018)}, 
-#' consisting of 37 magnetic sorted blood cell references and 12 samples, 
-#' formatted as an RGChannelSet object for  integration and normalization using
+#' from the immunomethylomics group (manuscript submitted), consisting of 37 
+#' magnetic sorted blood cell references and 12 samples, formatted as an
+#' RGChannelSet object for  integration and normalization using
 #' most of the existing Bioconductor packages.
 #'
 #' This package contains data similar to the FlowSorted.Blood.450k
@@ -34,22 +33,24 @@
 #'
 #'
 #' @format A class: RGChannelSet, dimensions: 1051815 49 
-#' @source The FlowSorted.Blood.EPIC object is based in samples assayed
-#' by Brock Christensen and colleagues; Salas et al. 2018. 
-#' \href{https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE110554}{GSE110554}
+#' @source \url{https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE110554}
+#' The FlowSorted.Blood.EPIC object is based in samples assayed
+#' by Brock Christensen and colleagues; manuscript submmited.
 #' @seealso
 #' References \enumerate{
 #' \item LA Salas et al. (2018). \emph{An optimized library for 
 #' reference-based deconvolution of whole-blood biospecimens assayed using the 
 #' Illumina HumanMethylationEPIC BeadArray}. Genome Biology 19, 64. doi:
-#' \href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}.
+#' 10.1186/s13059-018-1448-7.
 #' \item DC Koestler et al. (2016). \emph{Improving cell mixture deconvolution 
 #' by identifying optimal DNA methylation libraries (IDOL)}. BMC bioinformatics.
-#' 17, 120. doi:\href{https://dx.doi.org/10.1186/s12859-016-0943-7}{10.1186/s12859-016-0943-7}.
+#' 17, 120. doi: 10.1186/s12859-016-0943-7.
 #' \item EA Houseman et al. (2012) \emph{DNA methylation arrays as surrogate
 #' measures of cell mixture distribution}. BMC Bioinformatics 13, 86.
-#' doi:\href{https://dx.doi.org/10.1186/s12859-016-0943-7}{10.1186/1471-2105-13-86}.
-#' \item \pkg{minfi} package, tools for analyzing DNA methylation microarrays
+#' doi:10.1186/1471-2105-13-86.
+#' \item \pkg{minfi} package for tools for estimating cell type
+#' composition in blood using these data
+
 #' }
 #' 
 #' @examples

--- a/R/IDOLOptimizedCpGs.R
+++ b/R/IDOLOptimizedCpGs.R
@@ -15,11 +15,10 @@
 #' @references LA Salas et al. (2018). \emph{An optimized library for 
 #' reference-based deconvolution of whole-blood biospecimens assayed using the 
 #' Illumina HumanMethylationEPIC BeadArray}. Genome Biology 19, 64. doi:
-#' \href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}
+#' 10.1186/s13059-018-1448-7.
 #' @references DC Koestler et al. (2016). \emph{Improving cell mixture 
 #' deconvolution by identifying optimal DNA methylation libraries (IDOL)}. 
-#' BMC bioinformatics. 17, 120. doi: 
-#' \href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}.
+#' BMC bioinformatics. 17, 120. doi: 10.1186/s12859-016-0943-7.
 #' 
 #' @examples
 #' # Do not run

--- a/R/IDOLOptimizedCpGs.compTable.R
+++ b/R/IDOLOptimizedCpGs.compTable.R
@@ -16,11 +16,10 @@
 #' @references LA Salas et al. (2018). \emph{An optimized library for 
 #' reference-based deconvolution of whole-blood biospecimens assayed using the 
 #' Illumina HumanMethylationEPIC BeadArray}. Genome Biology 19, 64. doi:
-#' \href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}
+#' 10.1186/s13059-018-1448-7.
 #' @references DC Koestler et al. (2016). \emph{Improving cell mixture 
 #' deconvolution by identifying optimal DNA methylation libraries (IDOL)}. 
-#' BMC bioinformatics. 17, 120. doi: 
-#' \href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}.
+#' BMC bioinformatics. 17, 120. doi: 10.1186/s12859-016-0943-7.
 #' 
 #' @examples
 #' # Do not run

--- a/R/IDOLOptimizedCpGs450klegacy.R
+++ b/R/IDOLOptimizedCpGs450klegacy.R
@@ -16,11 +16,10 @@
 #' @references LA Salas et al. (2018). \emph{An optimized library for 
 #' reference-based deconvolution of whole-blood biospecimens assayed using the 
 #' Illumina HumanMethylationEPIC BeadArray}. Genome Biology 19, 64. doi:
-#' \href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}
-#' @references DC Koestler et al. (2016). \emph{Improving cell mixture 
+#' 10.1186/s13059-018-1448-7.
+#' @references D Koestler et al. (2016). \emph{Improving cell mixture 
 #' deconvolution by identifying optimal DNA methylation libraries (IDOL)}. 
-#' BMC bioinformatics. 17, 120. doi: 
-#' \href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}.
+#' BMC bioinformatics. 17, 120. doi: 10.1186/s12859-016-0943-7.
 #' 
 #' @examples
 #' # Do not run

--- a/R/IDOLOptimizedCpGs450klegacy.compTable.R
+++ b/R/IDOLOptimizedCpGs450klegacy.compTable.R
@@ -15,11 +15,10 @@
 #' @references LA Salas et al. (2018). \emph{An optimized library for 
 #' reference-based deconvolution of whole-blood biospecimens assayed using the 
 #' Illumina HumanMethylationEPIC BeadArray}. Genome Biology 19, 64. doi:
-#' \href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}
-#' @references DC Koestler et al. (2016). \emph{Improving cell mixture 
+#' 10.1186/s13059-018-1448-7.
+#' @references D Koestler et al. (2016). \emph{Improving cell mixture 
 #' deconvolution by identifying optimal DNA methylation libraries (IDOL)}. 
-#' BMC bioinformatics. 17, 120. doi: 
-#' \href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}.
+#' BMC bioinformatics. 17, 120. doi: 10.1186/s12859-016-0943-7.
 #' 
 #' @examples
 #' # Do not run

--- a/R/estimateCellCounts2.R
+++ b/R/estimateCellCounts2.R
@@ -1,6 +1,6 @@
-#' estimateCellCounts2 
-#' @description 
-#' estimateCellCounts2 function allows the use of customized reference   
+#' estimateCellCounts2
+#' @description
+#' estimateCellCounts2 function allows the use of customized reference
 #' datasets and IDOL probes L-DMR lists
 #' @import minfi
 #' @import SummarizedExperiment
@@ -24,91 +24,91 @@
 #' @importFrom nlme getVarCov
 #' @examples
 #' # Step 1: Load the reference library to extract the artificial mixtures
-#' 
+#'
 #' library(ExperimentHub)
 #' hub <- ExperimentHub()
 #' query(hub, "FlowSorted.Blood.EPIC")
 #' FlowSorted.Blood.EPIC <- hub[["EH1136"]]
 #' FlowSorted.Blood.EPIC
-#' 
-#' # Step 2 separate the reference from the testing dataset if you want to run 
+#'
+#' # Step 2 separate the reference from the testing dataset if you want to run
 #' # examples for estimations for this function example
-#' 
+#'
 #' RGsetTargets <- FlowSorted.Blood.EPIC[,
 #'              FlowSorted.Blood.EPIC$CellType == "MIX"]
-#'              
+#'
 #' sampleNames(RGsetTargets) <- paste(RGsetTargets$CellType,
 #'                             seq_len(dim(RGsetTargets)[2]), sep = "_")
 #' RGsetTargets
-#' 
+#'
 #' # Step 3: use your favorite package for deconvolution.
-#' # Deconvolute a target data set consisting of EPIC DNA methylation 
+#' # Deconvolute a target data set consisting of EPIC DNA methylation
 #' # data profiled in blood, using your prefered method.
-#' 
+#'
 #' # You can use our IDOL optimized DMR library for the EPIC array.  This object
 #' # contains a vector of length 450 consisting of the IDs of the IDOL optimized
 #' # CpG probes.  These CpGs are used as the backbone for deconvolution and were
-#' # selected because their methylation signature differs across the six normal 
+#' # selected because their methylation signature differs across the six normal
 #' # leukocyte subtypes.
-#' 
+#'
 #' data (IDOLOptimizedCpGs)
 #' head (IDOLOptimizedCpGs)
-#' # If you need to deconvolute a 450k legacy dataset use 
+#' # If you need to deconvolute a 450k legacy dataset use
 #' # IDOLOptimizedCpGs450klegacy instead
-#' 
-#' # We recommend using Noob processMethod = "preprocessNoob" in minfi for the 
-#' # target and reference datasets. 
+#'
+#' # We recommend using Noob processMethod = "preprocessNoob" in minfi for the
+#' # target and reference datasets.
 #' # Cell types included are "CD8T", "CD4T", "NK", "Bcell", "Mono", "Neu"
-#' 
-#' # To use the IDOL optimized list of CpGs (IDOLOptimizedCpGs) use 
-#' # estimateCellCounts2 an adaptation of the popular estimateCellCounts in 
-#' # minfi. This function also allows including customized reference arrays. 
-#' 
-#' # Do not run with limited RAM the normalization step requires a big amount 
+#'
+#' # To use the IDOL optimized list of CpGs (IDOLOptimizedCpGs) use
+#' # estimateCellCounts2 an adaptation of the popular estimateCellCounts in
+#' # minfi. This function also allows including customized reference arrays.
+#'
+#' # Do not run with limited RAM the normalization step requires a big amount
 #' # of memory resources
-#' 
+#'
 #' if (memory.limit()>8000){
-#'  countsEPIC<-estimateCellCounts2(RGsetTargets, compositeCellType = "Blood", 
+#'  countsEPIC<-estimateCellCounts2(RGsetTargets, compositeCellType = "Blood",
 #'                                 processMethod = "preprocessNoob",
-#'                                 probeSelect = "IDOL", 
-#'                                 cellTypes = c("CD8T", "CD4T", "NK", "Bcell", 
-#'                                 "Mono", "Neu"), 
-#'                                 referencePlatform = 
+#'                                 probeSelect = "IDOL",
+#'                                 cellTypes = c("CD8T", "CD4T", "NK", "Bcell",
+#'                                 "Mono", "Neu"),
+#'                                 referencePlatform =
 #'                                 "IlluminaHumanMethylationEPIC",
 #'                                 referenceset = NULL,
-#'                                 IDOLOptimizedCpGs =IDOLOptimizedCpGs, 
+#'                                 IDOLOptimizedCpGs =IDOLOptimizedCpGs,
 #'                                 returnAll = FALSE)
-#'                                 
+#'
 #' head(countsEPIC$counts)
 #' }
-#' 
+#'
 #' # CIBERSORT and/or RPC deconvolution
 #' # If you prefer CIBERSORT or RPC deconvolution use EpiDISH or similar
-#' 
+#'
 #' # Example not to run
-#' 
-#' # countsEPIC<-estimateCellCounts2(RGsetTargets, compositeCellType = "Blood", 
+#'
+#' # countsEPIC<-estimateCellCounts2(RGsetTargets, compositeCellType = "Blood",
 #' #                                processMethod = "preprocessNoob",
-#' #                                probeSelect = "IDOL", 
-#' #                                cellTypes = c("CD8T", "CD4T", "NK", 
-#' #                                "Bcell", "Mono", "Neu"), 
-#' #                                referencePlatform = 
+#' #                                probeSelect = "IDOL",
+#' #                                cellTypes = c("CD8T", "CD4T", "NK",
+#' #                                "Bcell", "Mono", "Neu"),
+#' #                                referencePlatform =
 #' #                                "IlluminaHumanMethylationEPIC",
 #' #                                referenceset = NULL,
-#' #                                IDOLOptimizedCpGs =IDOLOptimizedCpGs, 
+#' #                                IDOLOptimizedCpGs =IDOLOptimizedCpGs,
 #' #                                returnAll = TRUE)
-#' 
+#'
 #' # library(EpiDISH)
-#' # RPC <- epidish(getBeta(countsEPIC2$normalizedData), 
+#' # RPC <- epidish(getBeta(countsEPIC2$normalizedData),
 #' # as.matrix(countsEPIC2$compTable[IDOLOptimizedCpGs, 3:8]), method = "RPC")
 #' # RPC$estF#RPC count estimates
-#' 
-#' # CBS <- epidish(getBeta(countsEPIC2$normalizedData), 
+#'
+#' # CBS <- epidish(getBeta(countsEPIC2$normalizedData),
 #' # as.matrix(countsEPIC2$compTable[IDOLOptimizedCpGs, 3:8]), method = "CBS")
 #' # CBS$estF#CBS count estimates
-#' 
+#'
 #' # UMBILICAL CORD BLOOD DECONVOLUTION
-#' 
+#'
 #' # Do not run
 #' # library (FlowSorted.Blood.EPIC)
 #' # data("IDOLOptimizedCpGsCordBlood")
@@ -118,204 +118,204 @@
 #' # myfiles <- query(hub, "FlowSorted.CordBloodCombined.450k")
 #' # FlowSorted.CordBloodCombined.450k <- myfiles[[1]]
 #' # FlowSorted.CordBloodCombined.450k
-#' 
-#' # Step 2 separate the reference from the testing dataset if you want to run 
+#'
+#' # Step 2 separate the reference from the testing dataset if you want to run
 #' # examples for estimations for this function example
-#' 
+#'
 #' # RGsetTargets <- FlowSorted.CordBloodCombined.450k[,
 #' # FlowSorted.CordBloodCombined.450k$CellType == "WBC"]
 #' # sampleNames(RGsetTargets) <- paste(RGsetTargets$CellType,
 #' #                               seq_len(dim(RGsetTargets)[2]), sep = "_")
 #' # RGsetTargets
-#' 
+#'
 #' # Step 3: use your favorite package for deconvolution.
-#' # Deconvolute a target data set consisting of 450K DNA methylation 
+#' # Deconvolute a target data set consisting of 450K DNA methylation
 #' # data profiled in blood, using your prefered method.
 #' # You can use our IDOL optimized DMR library for the Cord Blood,  This object
 #' # contains a vector of length 517 consisting of the IDs of the IDOL optimized
 #' # CpG probes.  These CpGs are used as the backbone for deconvolution and were
-#' # selected because their methylation signature differs across the six normal 
+#' # selected because their methylation signature differs across the six normal
 #' # leukocyte subtypes plus the nucleated red blood cells.
-#' 
+#'
 #' # data (IDOLOptimizedCpGsCordBlood)
 #' # head (IDOLOptimizedCpGsCordBlood)
-#' # We recommend using Noob processMethod = "preprocessNoob" in minfi for the 
-#' # target and reference datasets. 
-#' # Cell types included are "CD8T", "CD4T", "NK", "Bcell", "Mono", "Gran", 
+#' # We recommend using Noob processMethod = "preprocessNoob" in minfi for the
+#' # target and reference datasets.
+#' # Cell types included are "CD8T", "CD4T", "NK", "Bcell", "Mono", "Gran",
 #' # "nRBC"
-#' # To use the IDOL optimized list of CpGs (IDOLOptimizedCpGsCordBlood) use 
-#' # estimateCellCounts2 from FlowSorted.Blood.EPIC. 
-#' # Do not run with limited RAM the normalization step requires a big amount 
-#' # of memory resources. Use the parameters as specified below for 
+#' # To use the IDOL optimized list of CpGs (IDOLOptimizedCpGsCordBlood) use
+#' # estimateCellCounts2 from FlowSorted.Blood.EPIC.
+#' # Do not run with limited RAM the normalization step requires a big amount
+#' # of memory resources. Use the parameters as specified below for
 #' # reproducibility.
-#' # 
+#' #
 #' # if (memory.limit()>8000){
-#' #     countsUCB<-estimateCellCounts2(RGsetTargets, 
-#' #                                     compositeCellType = 
-#' #                                                "CordBloodCombined", 
+#' #     countsUCB<-estimateCellCounts2(RGsetTargets,
+#' #                                     compositeCellType =
+#' #                                                "CordBloodCombined",
 #' #                                     processMethod = "preprocessNoob",
-#' #                                     probeSelect = "IDOL", 
-#' #                                     cellTypes = c("CD8T", "CD4T", "NK",  
-#' #                                     "Bcell", "Mono", "Gran", "nRBC"), 
-#' #                                     referencePlatform = 
+#' #                                     probeSelect = "IDOL",
+#' #                                     cellTypes = c("CD8T", "CD4T", "NK",
+#' #                                     "Bcell", "Mono", "Gran", "nRBC"),
+#' #                                     referencePlatform =
 #' #                                         "IlluminaHumanMethylation450k",
-#' #                                     referenceset = 
+#' #                                     referenceset =
 #' #                                      "FlowSorted.CordBloodCombined.450k",
 #' #                                     IDOLOptimizedCpGs =
-#' #                                       IDOLOptimizedCpGsCordBlood, 
+#' #                                       IDOLOptimizedCpGsCordBlood,
 #' #                                     returnAll = FALSE)
-#' #     
+#' #
 #' #     head(countsUCB$counts)
 #' # }
-#' 
-#' @references LA Salas et al. (2018). \emph{An optimized library for 
-#' reference-based deconvolution of whole-blood biospecimens assayed using the 
+#'
+#' @references LA Salas et al. (2018). \emph{An optimized library for
+#' reference-based deconvolution of whole-blood biospecimens assayed using the
 #' Illumina HumanMethylationEPIC BeadArray}. Genome Biology 19, 64. doi:
 #' \href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}
-#' @references DC Koestler et al. (2016). \emph{Improving cell mixture 
-#' deconvolution by identifying optimal DNA methylation libraries (IDOL)}. 
-#' BMC bioinformatics. 17, 120. doi: 
+#' @references DC Koestler et al. (2016). \emph{Improving cell mixture
+#' deconvolution by identifying optimal DNA methylation libraries (IDOL)}.
+#' BMC bioinformatics. 17, 120. doi:
 #' \href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}.
-#' @references EA Houseman, et al.(2012)  \emph{DNA methylation arrays as 
-#' surrogate measures of cell mixture distribution}. BMC bioinformatics  13:86. 
+#' @references EA Houseman, et al.(2012)  \emph{DNA methylation arrays as
+#' surrogate measures of cell mixture distribution}. BMC bioinformatics  13:86.
 #' doi:\href{https://dx.doi.org/10.1186/s12859-016-0943-7}{10.1186/1471-2105-13-86}.
-#' @references AE Jaffe and RA Irizarry.(2014) \emph{Accounting for cellular 
-#' heterogeneity is critical in epigenome-wide association studies}. 
+#' @references AE Jaffe and RA Irizarry.(2014) \emph{Accounting for cellular
+#' heterogeneity is critical in epigenome-wide association studies}.
 #' Genome Biology  15:R31. doi:
 #' \href{https://dx.doi.org/10.1186/gb-2014-15-2-r31}{10.1186/gb-2014-15-2-r31}.
-#' @references K Gervin, LA Salas et al. (2019) \emph{Systematic evaluation and 
-#' validation of references and library selection methods for deconvolution of 
+#' @references K Gervin, LA Salas et al. (2019) \emph{Systematic evaluation and
+#' validation of references and library selection methods for deconvolution of
 #' cord blood DNA methylation data}. Clin Epigenetics 11,125. doi:
 #' \href{https://dx.doi.org/10.1186/s13148-019-0717-y}{10.1186/s13148-019-0717-y}.
-#' @references KM Bakulski, et al. (2016) \emph{DNA methylation of cord blood 
-#' cell types: Applications for mixed cell birth studies}. Epigenetics 11:5. 
+#' @references KM Bakulski, et al. (2016) \emph{DNA methylation of cord blood
+#' cell types: Applications for mixed cell birth studies}. Epigenetics 11:5.
 #' doi:\href{https://dx.doi.org/10.1080/15592294.2016.1161875}{10.1080/15592294.2016.1161875}.
-#' @references AJ Titus, et al. (2017). \emph{Cell-type deconvolution from DNA 
+#' @references AJ Titus, et al. (2017). \emph{Cell-type deconvolution from DNA
 #' methylation: a review of recent applications}. Hum Mol Genet 26: R216-R224.
 #' doi:\href{https://dx.doi.org/10.1093/hmg/ddx275}{10.1093/hmg/ddx275}
-#' @references AE Teschendorff, et al. (2017). \emph{A comparison of 
-#' reference-based algorithms for correcting cell-type heterogeneity in 
+#' @references AE Teschendorff, et al. (2017). \emph{A comparison of
+#' reference-based algorithms for correcting cell-type heterogeneity in
 #' Epigenome-Wide Association Studies}. BMC Bioinformatics 18: 105. doi:
 #' \href{https://dx.doi.org/10.1186/s12859-017-1511-5}{10.1186/s12859-017-1511-5}
-#' @param 
+#' @param
 #' rgSet           The input RGChannelSet or raw MethylSet for the procedure.
 #' @param
-#' compositeCellType   Which composite cell type is being deconvoluted. 
+#' compositeCellType   Which composite cell type is being deconvoluted.
 #'                      Should be one of "Blood", "CordBloodCombined",
 #'                      "CordBlood", "CordBloodNorway", "CordTissueAndBlood",
 #'                      or "DLPFC".
 #'                      See details for preferred approaches.
 #' @param
-#' processMethod Joint normalization/background correction for user and 
-#'                reference data 
-#'                
-#'                Default input, "preprocessNoob" in minfi, you can use "auto" 
-#'                for preprocessQuantile for Blood and DLPFC in 450K datasets 
-#'                and preprocessNoob otherwise, according to existing 
-#'                literature. 
-#'                
-#'                For MethylSet objects only "preprocessQuantile"  
-#'                is available. Set it to any minfi preprocessing function as a 
-#'                character if you want to override it, like 
+#' processMethod Joint normalization/background correction for user and
+#'                reference data
+#'
+#'                Default input, "preprocessNoob" in minfi, you can use "auto"
+#'                for preprocessQuantile for Blood and DLPFC in 450K datasets
+#'                and preprocessNoob otherwise, according to existing
+#'                literature.
+#'
+#'                For MethylSet objects only "preprocessQuantile"
+#'                is available. Set it to any minfi preprocessing function as a
+#'                character if you want to override it, like
 #'                "preprocessFunnorm"
-#' @param 
-#' probeSelect    How should probes be selected to distinguish cell types? 
-#' 
+#' @param
+#' probeSelect    How should probes be selected to distinguish cell types?
+#'
 #'                Options include:
 #'                1)  "IDOL", for using a customized set of probes obtained from
-#'                 IDOL optimization, available for Blood and Umbilical Cord 
-#'                 Blood 
-#'                2) "both", which selects an equal number (50) of probes (with 
-#'                F-stat p-value < 1E-8) with the greatest magnitude of effect 
-#'                from the hyper- and hypo-methylated sides, and 
-#'                3) "any", which selects the 100 probes (with F-stat p-value 
-#'                < 1E-8) with the greatest magnitude of difference regardless 
-#'                of direction of effect.  
-#'                
-#'                
-#'                This according to minfi algorithm. Default input "auto" in  
-#'                minfi will use "any" for cord blood and "both" otherwise.  
+#'                 IDOL optimization, available for Blood and Umbilical Cord
+#'                 Blood
+#'                2) "both", which selects an equal number (50) of probes (with
+#'                F-stat p-value < 1E-8) with the greatest magnitude of effect
+#'                from the hyper- and hypo-methylated sides, and
+#'                3) "any", which selects the 100 probes (with F-stat p-value
+#'                < 1E-8) with the greatest magnitude of difference regardless
+#'                of direction of effect.
+#'
+#'
+#'                This according to minfi algorithm. Default input "auto" in
+#'                minfi will use "any" for cord blood and "both" otherwise.
 #'                Please see references for more details.
-#' @param 
-#' cellTypes     A vector of length K that contains the cell type names.  
+#' @param
+#' cellTypes     A vector of length K that contains the cell type names.
 #'                Default: c("CD8T", "CD4T", "NK", "Bcell", "Mono", "Neu").
-#'                Please notice that this library use Neutrophils instead 
+#'                Please notice that this library use Neutrophils instead
 #'                of Granulocytes. See details for your library.
-#' @param                 
-#' referencePlatform The platform for the reference dataset; if the input  
-#'                    rgSet belongs to another platform, it will be converted  
+#' @param
+#' referencePlatform The platform for the reference dataset; if the input
+#'                    rgSet belongs to another platform, it will be converted
 #'                    using minfi function convertArray.
 #' @param
-#' referenceset It is NULL by default.  
-#'             
-#'             A custom reference RGChannelSet object (in quotes) if it is not 
+#' referenceset It is NULL by default.
+#'
+#'             A custom reference RGChannelSet object (in quotes) if it is not
 #'             a package installed. This option also allows the user to perform
 #'             the deconvolution in closed computing clusters without internet
-#'             access to ExperimentHub. For that download and save the 
-#'             reference and input the resulting object here. If using an 
+#'             access to ExperimentHub. For that download and save the
+#'             reference and input the resulting object here. If using an
 #'             installed reference package set to NULL.
 #' @param
-#' IDOLOptimizedCpGs a vector of probe names for cell deconvolution. For 
-#'                 EPIC datasets it should be equal to IDOLOptimizedCpGs (no 
-#'                 quotes). For legacy 450K datasets you can use 
-#'                 IDOLOptimizedCpGs450klegacy (no quotes) if you want to use 
+#' IDOLOptimizedCpGs a vector of probe names for cell deconvolution. For
+#'                 EPIC datasets it should be equal to IDOLOptimizedCpGs (no
+#'                 quotes). For legacy 450K datasets you can use
+#'                 IDOLOptimizedCpGs450klegacy (no quotes) if you want to use
 #'                 FlowSorted.EPIC.Blood for the deconvolution. For umbilical
-#'                 cord blood use IDOLOptimizedCpGsCordBlood in the 
+#'                 cord blood use IDOLOptimizedCpGsCordBlood in the
 #'                 FlowSorted.CordBloodCombined.450k package for both 450k and
 #'                 EPIC arrays. See details in help for each IDOL list.
-#' @param 
-#' returnAll    Should the composition table and the normalized user supplied 
+#' @param
+#' returnAll    Should the composition table and the normalized user supplied
 #'              data be return? Default is False.
-#' @param              
+#' @param
 #' verbose Should the function be verbose?
 #' @param
-#' meanPlot    Whether to plots the average DNA methylation across the  
-#'             cell-type discriminating probes within the mixed and sorted 
+#' meanPlot    Whether to plots the average DNA methylation across the
+#'             cell-type discriminating probes within the mixed and sorted
 #'             samples.
-#' @param 
-#' lessThanOne Should the predictions be constrained to exactly one, 
+#' @param
+#' lessThanOne Should the predictions be constrained to exactly one,
 #'             in minfi default is FALSE, now you can select the option
-#' @param 
+#' @param
 #' ...  Other arguments for preprocessquantile or other normalizations
 #'@return
-#' This function will return a list containing matrix of cell counts (counts), 
-#' if returnAll=FALSE, or a list containing the counts, mean methylation per 
-#' cellType, and the normalized betas (if returnAll is set to TRUE). These 
-#' objects are important if you decide to use a different deconvolution 
+#' This function will return a list containing matrix of cell counts (counts),
+#' if returnAll=FALSE, or a list containing the counts, mean methylation per
+#' cellType, and the normalized betas (if returnAll is set to TRUE). These
+#' objects are important if you decide to use a different deconvolution
 #' algorithm such as CIBERSORT or robust partial correlation (RPC).
 #' @export
-estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood", 
-                                processMethod = "preprocessNoob", 
-                                probeSelect = c("auto", "any", "IDOL"), 
-                                cellTypes = c("CD8T", "CD4T", "NK", "Bcell", 
-                                                "Mono", "Neu"), 
-                        referencePlatform = c("IlluminaHumanMethylation450k", 
-                                                "IlluminaHumanMethylationEPIC", 
-                                                "IlluminaHumanMethylation27k"), 
-                                referenceset = NULL, IDOLOptimizedCpGs = NULL, 
-                                returnAll = FALSE, meanPlot = FALSE, 
+estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
+                                processMethod = "preprocessNoob",
+                                probeSelect = c("auto", "any", "IDOL"),
+                                cellTypes = c("CD8T", "CD4T", "NK", "Bcell",
+                                                "Mono", "Neu"),
+                        referencePlatform = c("IlluminaHumanMethylation450k",
+                                                "IlluminaHumanMethylationEPIC",
+                                                "IlluminaHumanMethylation27k"),
+                                referenceset = NULL, IDOLOptimizedCpGs = NULL,
+                                returnAll = FALSE, meanPlot = FALSE,
                                 verbose = TRUE, lessThanOne = FALSE,
                                 ...) {
-    if ((!is(rgSet, "RGChannelSet")) && (!is(rgSet, "MethylSet")))  
-        stop(strwrap(sprintf("object is of class '%s', but needs to be of 
-                                class 'RGChannelSet' 'RGChannelSetExtended' or 
-                                'MethylSet' to use this function", 
-                            class(rgSet)), width = 80, prefix = " ", 
+    if ((!is(rgSet, "RGChannelSet")) && (!is(rgSet, "MethylSet")))
+        stop(strwrap(sprintf("object is of class '%s', but needs to be of
+                                class 'RGChannelSet' 'RGChannelSetExtended' or
+                                'MethylSet' to use this function",
+                            class(rgSet)), width = 80, prefix = " ",
                     initial = ""))
-    if (!is(rgSet, "RGChannelSet") && 
-        (processMethod[1] != "preprocessQuantile")) 
-        stop(strwrap(sprintf("object is of class '%s', but needs to be of 
-                                class 'RGChannelSet' or 'RGChannelSetExtended' 
-                                to use other methods different to 
+    if (!is(rgSet, "RGChannelSet") &&
+        (processMethod[1] != "preprocessQuantile"))
+        stop(strwrap(sprintf("object is of class '%s', but needs to be of
+                                class 'RGChannelSet' or 'RGChannelSetExtended'
+                                to use other methods different to
                                 'preprocessQuantile'", class(rgSet)),
                     width = 80, prefix = " ", initial = ""))
-    if (is(rgSet, "MethylSet") && 
-        (processMethod[1] == "preprocessQuantile")) 
+    if (is(rgSet, "MethylSet") &&
+        (processMethod[1] == "preprocessQuantile"))
         message(strwrap("[estimateCellCounts2] The function will assume that
-                            no preprocessing has been performed. Using 
-                            'preprocessQuantile' in prenormalized data is 
-                            experimental and it should only be run under the 
-                            user responsibility",width = 80, prefix = " ", 
+                            no preprocessing has been performed. Using
+                            'preprocessQuantile' in prenormalized data is
+                            experimental and it should only be run under the
+                            user responsibility",width = 80, prefix = " ",
                         initial = ""))
     if (is(rgSet, "RGChannelSetExtended"))
         rgSet <- as(rgSet, "RGChannelSet")
@@ -323,39 +323,39 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
     rgPlatform <- sub("IlluminaHumanMethylation", "",
                 annotation(rgSet)[which(names(annotation(rgSet)) == "array")])
     platform <- sub("IlluminaHumanMethylation", "", referencePlatform)
-    if ((compositeCellType == "CordBlood" | 
-        compositeCellType == "CordBloodCombined") && (!"nRBC" %in% cellTypes)) 
-        message(strwrap("[estimateCellCounts2] Consider including 'nRBC' in 
+    if ((compositeCellType == "CordBlood" |
+        compositeCellType == "CordBloodCombined") && (!"nRBC" %in% cellTypes))
+        message(strwrap("[estimateCellCounts2] Consider including 'nRBC' in
                         argument 'cellTypes' for cord blood estimation.\n",
                         width = 80, prefix = " ", initial = ""))
-    if ((compositeCellType == "Blood") && 
-        (referencePlatform == "IlluminaHumanMethylationEPIC") && 
-        ("Gran" %in% cellTypes)) 
-        message(strwrap("[estimateCellCounts2] Replace 'Gran' for 'Neu' in 
+    if ((compositeCellType == "Blood") &&
+        (referencePlatform == "IlluminaHumanMethylationEPIC") &&
+        ("Gran" %in% cellTypes))
+        message(strwrap("[estimateCellCounts2] Replace 'Gran' for 'Neu' in
                         argument 'cellTypes' for EPIC blood estimation.\n",
                         width = 80, prefix = " ", initial = ""))
-    if ((compositeCellType != "Blood") && 
-        ("Neu" %in% cellTypes)) 
-        message(strwrap("[estimateCellCounts2] Check whether 'Gran' or 'Neu' is 
-                        present in your reference and adjust argument 
+    if ((compositeCellType != "Blood") &&
+        ("Neu" %in% cellTypes))
+        message(strwrap("[estimateCellCounts2] Check whether 'Gran' or 'Neu' is
+                        present in your reference and adjust argument
                         'cellTypes' for your estimation.\n",
                         width = 80, prefix = " ", initial = ""))
     if (compositeCellType == "CordBloodCombined")
-        platform<="450k"
+        platform <- "450k"
     referencePkg <- sprintf("FlowSorted.%s.%s", compositeCellType, platform)
     subverbose <- max(as.integer(verbose) - 1L, 0L)
     if (!is.null(referenceset)){
         referenceRGset<- get(referenceset)
         if (!is(rgSet, "RGChannelSet"))
             referenceRGset<-preprocessRaw(referenceRGset)
-    } else{ 
-        if (!require(referencePkg, character.only = TRUE)) 
-            stop(strwrap(sprintf("Could not find reference data package for 
-                                compositeCellType '%s' and referencePlatform 
-                                '%s' (inferred package name is '%s')", 
+    } else{
+        if (!require(referencePkg, character.only = TRUE))
+            stop(strwrap(sprintf("Could not find reference data package for
+                                compositeCellType '%s' and referencePlatform
+                                '%s' (inferred package name is '%s')",
                                 compositeCellType, platform, referencePkg),
                         width = 80, prefix = " ", initial = ""))
-        if((referencePkg!="FlowSorted.Blood.EPIC")  && 
+        if((referencePkg!="FlowSorted.Blood.EPIC")  &&
             (referencePkg!="FlowSorted.CordBloodCombined.450k")){
             referenceRGset <- get(referencePkg)
         } else if (referencePkg=="FlowSorted.Blood.EPIC"){
@@ -363,59 +363,59 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
             referenceRGset <-hub[["EH1136"]]
         } else if (referencePkg=="FlowSorted.CordBloodCombined.450k"){
             hub <- ExperimentHub()
-            referenceRGset <-hub[["EH2256"]]            
+            referenceRGset <-hub[["EH2256"]]
         }
         if (!is(rgSet, "RGChannelSet"))
-            referenceRGset<-preprocessRaw(referenceRGset) 
-    }   
+            referenceRGset<-preprocessRaw(referenceRGset)
+    }
     if (rgPlatform != platform) {
-        rgSet <- convertArray(rgSet, outType = referencePlatform, 
+        rgSet <- convertArray(rgSet, outType = referencePlatform,
                                 verbose = TRUE)
     }
-    if (!"CellType" %in% names(colData(referenceRGset))) 
-        stop(strwrap(sprintf("the reference sorted dataset (in this case '%s') 
-                            needs to have a phenoData column called 
+    if (!"CellType" %in% names(colData(referenceRGset)))
+        stop(strwrap(sprintf("the reference sorted dataset (in this case '%s')
+                            needs to have a phenoData column called
                             'CellType'"), names(referencePkg),
                     width = 80, prefix = " ", initial = ""))
-    if (sum(colnames(rgSet) %in% colnames(referenceRGset)) > 0) 
-        stop(strwrap("the sample/column names in the user set must not be in 
-                    the reference data ", width = 80, prefix = " ", 
+    if (sum(colnames(rgSet) %in% colnames(referenceRGset)) > 0)
+        stop(strwrap("the sample/column names in the user set must not be in
+                    the reference data ", width = 80, prefix = " ",
                     initial = ""))
-    if (!all(cellTypes %in% referenceRGset$CellType)) 
-        stop(strwrap(sprintf("all elements of argument 'cellTypes' needs to be 
-                            part of the reference phenoData columns 'CellType' 
-                            (containg the following elements: '%s')", 
-                            paste(unique(referenceRGset$cellType), 
-                                    collapse = "', '")), width = 80, 
+    if (!all(cellTypes %in% referenceRGset$CellType))
+        stop(strwrap(sprintf("all elements of argument 'cellTypes' needs to be
+                            part of the reference phenoData columns 'CellType'
+                            (containg the following elements: '%s')",
+                            paste(unique(referenceRGset$cellType),
+                                    collapse = "', '")), width = 80,
                     prefix = " ", initial = ""))
-    if (length(unique(cellTypes)) < 2) 
+    if (length(unique(cellTypes)) < 2)
         stop("At least 2 cell types must be provided.")
-    if ((processMethod == "auto") && 
-        (compositeCellType %in% c("Blood", "DLPFC"))) 
+    if ((processMethod == "auto") &&
+        (compositeCellType %in% c("Blood", "DLPFC")))
         processMethod <- "preprocessQuantile"
-    if ((processMethod == "auto") && 
-        (!compositeCellType %in% c("Blood","DLPFC")) && 
-        (is(rgSet, "RGChannelSet"))) 
+    if ((processMethod == "auto") &&
+        (!compositeCellType %in% c("Blood","DLPFC")) &&
+        (is(rgSet, "RGChannelSet")))
         processMethod <- "preprocessNoob"
     processMethod <- get(processMethod)
-    if ((probeSelect == "auto") && 
-        (compositeCellType %in% c("CordBloodCombined", "CordBlood", 
+    if ((probeSelect == "auto") &&
+        (compositeCellType %in% c("CordBloodCombined", "CordBlood",
                                     "CordBloodNorway", "CordTissueAndBlood"))) {
         probeSelect <- "any"
     }
-    if ((probeSelect == "auto") && 
-        (!compositeCellType %in% c("CordBloodCombined", "CordBlood", 
+    if ((probeSelect == "auto") &&
+        (!compositeCellType %in% c("CordBloodCombined", "CordBlood",
                                     "CordBloodNorway", "CordTissueAndBlood"))) {
         probeSelect <- "both"
     }
-    if (verbose) 
-        message(strwrap("[estimateCellCounts2] Combining user data with 
-                        reference (flow sorted) data.\n", width = 80, 
+    if (verbose)
+        message(strwrap("[estimateCellCounts2] Combining user data with
+                        reference (flow sorted) data.\n", width = 80,
                         prefix = " ", initial = ""))
-    newpd <- DataFrame(sampleNames = c(colnames(rgSet), 
-                                        colnames(referenceRGset)), 
-                        studyIndex = rep(c("user", "reference"), 
-                                        times = c(ncol(rgSet), 
+    newpd <- DataFrame(sampleNames = c(colnames(rgSet),
+                                        colnames(referenceRGset)),
+                        studyIndex = rep(c("user", "reference"),
+                                        times = c(ncol(rgSet),
                                                     ncol(referenceRGset))))
     referenceRGset$CellType<-as.character(referenceRGset$CellType)
     if(is.null(rgSet$CellType))
@@ -434,13 +434,13 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
     }else{
         try(referenceRGset$Age<-as.numeric(referenceRGset$Age))
     }
-    commoncolumn<-intersect(names(colData(rgSet)), 
+    commoncolumn<-intersect(names(colData(rgSet)),
                             names(colData(referenceRGset)))
     restry<-try({colData(rgSet)[commoncolumn] <- mapply(FUN = as,
                                         colData(rgSet)[commoncolumn],
                                 vapply(colData(referenceRGset)[commoncolumn],
                                                 class, FUN.VALUE=character(1)),
-                                                    SIMPLIFY = FALSE)}, 
+                                                    SIMPLIFY = FALSE)},
                                                     silent = TRUE)
     if ( "try-error" %in% class(restry) ) {
         commoncolumn<-c("CellType", "Sex", "Age")
@@ -458,13 +458,13 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
     colData(referenceRGset)<-colData(referenceRGset)[commoncolumn]
     colData(rgSet)<-colData(rgSet)[commoncolumn]
     referencePd <- colData(referenceRGset)
-    combinedRGset <- combineArrays(rgSet, referenceRGset, 
+    combinedRGset <- combineArrays(rgSet, referenceRGset,
                                     outType = referencePlatform)
     colData(combinedRGset) <- newpd
     colnames(combinedRGset) <- newpd$sampleNames
     rm(referenceRGset)
-    if (verbose) 
-        message(strwrap("[estimateCellCounts2] Processing user and reference 
+    if (verbose)
+        message(strwrap("[estimateCellCounts2] Processing user and reference
                         data together.\n", width = 80, prefix = " ",
                         initial = ""))
     if (compositeCellType == "CordBlood") {
@@ -475,7 +475,7 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
         rm(combinedRGset)
         gc()
         compTable <- get(paste0(referencePkg, ".compTable"))
-        combinedMset <- combinedMset[which(rownames(combinedMset) %in% 
+        combinedMset <- combinedMset[which(rownames(combinedMset) %in%
                                                 rownames(compTable)), ]
     } else {
         if (!is(combinedRGset, "RGChannelSet"))
@@ -491,15 +491,15 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
     colData(mSet) <- as(colData(rgSet), "DataFrame")
     rm(combinedMset)
     if (probeSelect != "IDOL") {
-        if (verbose) 
-            message(strwrap("[estimateCellCounts2] Picking probes for 
-                            composition estimation.\n", width = 80, 
+        if (verbose)
+            message(strwrap("[estimateCellCounts2] Picking probes for
+                            composition estimation.\n", width = 80,
                             prefix = " ", initial = ""))
-        compData <- pickCompProbes(referenceMset, cellTypes = cellTypes, 
-                                    compositeCellType = compositeCellType, 
+        compData <- pickCompProbes(referenceMset, cellTypes = cellTypes,
+                                    compositeCellType = compositeCellType,
                                     probeSelect = probeSelect)
         coefs <- compData$coefEsts
-        if (verbose) 
+        if (verbose)
             message("[estimateCellCounts2] Estimating composition.\n")
         counts <- projectCellType(getBeta(mSet)[rownames(coefs), ], coefs,
                                 lessThanOne = lessThanOne)
@@ -507,32 +507,32 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
         if (meanPlot) {
             smeans <- compData$sampleMeans
             smeans <- smeans[order(names(smeans))]
-            sampleMeans <- c(colMeans(minfi::getBeta(mSet)[rownames(coefs), ]), 
+            sampleMeans <- c(colMeans(minfi::getBeta(mSet)[rownames(coefs), ]),
                             smeans)
-            sampleColors <- c(rep(1, ncol(mSet)), 1 + 
+            sampleColors <- c(rep(1, ncol(mSet)), 1 +
                                 as.numeric(factor(names(smeans))))
             plot(sampleMeans, pch = 21, bg = sampleColors)
-            legend("bottomleft", c("blood", levels(factor(names(smeans)))), 
+            legend("bottomleft", c("blood", levels(factor(names(smeans)))),
                     col = seq_len(7), pch = 15)
         }
         if (returnAll) {
-            list(counts = counts, compTable = compData$compTable, 
+            list(counts = counts, compTable = compData$compTable,
                 normalizedData = mSet)
         } else {
-            list(counts = counts)  
+            list(counts = counts)
         }
     } else {
-        if (verbose) 
-            message(strwrap("[estimateCellCounts2] Using IDOL L-DMR probes for 
-                            composition estimation.\n", width = 80, 
+        if (verbose)
+            message(strwrap("[estimateCellCounts2] Using IDOL L-DMR probes for
+                            composition estimation.\n", width = 80,
                             prefix = " ", initial = ""))
         p <- getBeta(referenceMset)
         pd <- as.data.frame(colData(referenceMset))
         rm(referenceMset)
         if (!is.null(cellTypes)) {
-            if (!all(cellTypes %in% pd$CellType)) 
-                stop(strwrap("elements of argument 'cellTypes' is not part of 
-                            'referenceMset$CellType'", width = 80, 
+            if (!all(cellTypes %in% pd$CellType))
+                stop(strwrap("elements of argument 'cellTypes' is not part of
+                            'referenceMset$CellType'", width = 80,
                             prefix = " ", initial = ""))
             keep <- which(pd$CellType %in% cellTypes)
             pd <- pd[keep, ]
@@ -546,7 +546,7 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
         r <- rowRanges(p)
         compTable <- cbind(ffComp, prof, r, abs(r[, 1] - r[, 2]))
         names(compTable)[1] <- "Fstat"
-        names(compTable)[c(-2, -1, 0) + ncol(compTable)] <- c("low", 
+        names(compTable)[c(-2, -1, 0) + ncol(compTable)] <- c("low",
                                                             "high", "range")
         tstatList <- lapply(tIndexes, function(i) {
             x <- rep(0, ncol(p))
@@ -558,7 +558,7 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
         p <- p[trainingProbes, ]
         pMeans <- colMeans(p)
         names(pMeans) <- pd$CellType
-        form <- as.formula(sprintf("y ~ %s - 1", paste(levels(pd$CellType), 
+        form <- as.formula(sprintf("y ~ %s - 1", paste(levels(pd$CellType),
                                                         collapse = "+")))
         phenoDF <- as.data.frame(model.matrix(~pd$CellType - 1))
         colnames(phenoDF) <- sub("^pd\\$CellType", "", colnames(phenoDF))
@@ -573,7 +573,7 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
         }
         compData<-list(coefEsts = coefEsts, compTable = compTable,
                         sampleMeans = pMeans)
-        if (verbose) 
+        if (verbose)
             message("[estimateCellCounts2] Estimating composition.\n")
         counts <- projectCellType(getBeta(mSet)[rownames(coefs), ], coefs,
                                 lessThanOne = lessThanOne)
@@ -582,46 +582,46 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
             smeans <- compData$sampleMeans
             smeans <- smeans[order(names(smeans))]
             sampleMeans <- c(colMeans(getBeta(mSet)[rownames(coefs), ]), smeans)
-            sampleColors <- c(rep(1, ncol(mSet)), 1 + 
+            sampleColors <- c(rep(1, ncol(mSet)), 1 +
                                 as.numeric(factor(names(smeans))))
             plot(sampleMeans, pch = 21, bg = sampleColors)
-            legend("bottomleft", c("blood", levels(factor(names(smeans)))), 
+            legend("bottomleft", c("blood", levels(factor(names(smeans)))),
                     col = seq_len(7), pch = 15)
         }
         if (returnAll) {
             list(counts = counts, compTable = compTable, normalizedData = mSet)
         } else {
-            list(counts = counts)  
+            list(counts = counts)
         }
     }
 }
 
-#These are minfi internal functions here they are called to keep the function 
+#These are minfi internal functions here they are called to keep the function
 #above running for the alternative selection ("auto" and "both")
-pickCompProbes <- function(mSet, cellTypes = NULL, numProbes = 50, 
-                            compositeCellType = compositeCellType, 
+pickCompProbes <- function(mSet, cellTypes = NULL, numProbes = 50,
+                            compositeCellType = compositeCellType,
                             probeSelect = probeSelect) {
     p <- getBeta(mSet)
     pd <- as.data.frame(colData(mSet))
     if(!is.null(cellTypes)) {
         if(!all(cellTypes %in% pd$CellType))
-            stop(strwrap("elements of argument 'cellTypes' are not part of 
-                        'mSet$CellType'", width = 80, prefix = " ", 
+            stop(strwrap("elements of argument 'cellTypes' are not part of
+                        'mSet$CellType'", width = 80, prefix = " ",
                         initial = ""))
         keep <- which(pd$CellType %in% cellTypes)
         pd <- pd[keep,]
         p <- p[,keep]
     }
-    ## make cell type a factor 
+    ## make cell type a factor
     pd$CellType <- factor(pd$CellType, levels = cellTypes)
     ffComp <- rowFtests(p, pd$CellType)
     tIndexes <- split(seq(along=pd$CellType), pd$CellType)
-    prof <- vapply(tIndexes, function(i) rowMeans(p[,i]), 
+    prof <- vapply(tIndexes, function(i) rowMeans(p[,i]),
                     FUN.VALUE=numeric(dim(p)[1]))
     r <- rowRanges(p)
     compTable <- cbind(ffComp, prof, r, abs(r[,1] - r[,2]))
     names(compTable)[1] <- "Fstat"
-    names(compTable)[c(-2,-1,0) + ncol(compTable)] <- c("low", "high", "range") 
+    names(compTable)[c(-2,-1,0) + ncol(compTable)] <- c("low", "high", "range")
     tstatList <- lapply(tIndexes, function(i) {
         x <- rep(0,ncol(p))
         x[i] <- 1
@@ -630,7 +630,7 @@ pickCompProbes <- function(mSet, cellTypes = NULL, numProbes = 50,
     if (probeSelect == "any"){
         probeList <- lapply(tstatList, function(x) {
             y <- x[x[,"p.value"] < 1e-8,]
-            yAny <- y[order(abs(y[,"dm"]), decreasing=TRUE),]      
+            yAny <- y[order(abs(y[,"dm"]), decreasing=TRUE),]
             c(rownames(yAny)[seq_len(numProbes*2)])
         })
     } else {
@@ -638,16 +638,16 @@ pickCompProbes <- function(mSet, cellTypes = NULL, numProbes = 50,
             y <- x[x[,"p.value"] < 1e-8,]
             yUp <- y[order(y[,"dm"], decreasing=TRUE),]
             yDown <- y[order(y[,"dm"], decreasing=FALSE),]
-            c(rownames(yUp)[seq_len(numProbes)], 
+            c(rownames(yUp)[seq_len(numProbes)],
                 rownames(yDown)[seq_len(numProbes)])
         })
     }
     trainingProbes <- unique(unlist(probeList))
     p <- p[trainingProbes,]
-    
+
     pMeans <- colMeans(p)
     names(pMeans) <- pd$CellType
-    form <- as.formula(sprintf("y ~ %s - 1", paste(levels(pd$CellType), 
+    form <- as.formula(sprintf("y ~ %s - 1", paste(levels(pd$CellType),
                                                     collapse="+")))
     phenoDF <- as.data.frame(model.matrix(~pd$CellType-1))
     colnames(phenoDF) <- sub("^pd\\$CellType", "", colnames(phenoDF))
@@ -658,7 +658,7 @@ pickCompProbes <- function(mSet, cellTypes = NULL, numProbes = 50,
         tmp <- validationCellType(Y = p, pheno = phenoDF, modelFix = form)
         coefEsts <- tmp$coefEsts
     }
-    
+
     out <- list(coefEsts = coefEsts, compTable = compTable,
                 sampleMeans = pMeans)
     return(out)
@@ -668,37 +668,37 @@ pickCompProbes <- function(mSet, cellTypes = NULL, numProbes = 50,
 ###############################################################################
 # FUNCTION:  projectCellType
 #    This function predicts the underlying cellular composition of heterogeneous
-#    tissue types (i.e., WB) using the constrained projection procedure 
-#    described by Houseman et al., (2012) and modified in minfi.  
+#    tissue types (i.e., WB) using the constrained projection procedure
+#    described by Houseman et al., (2012) and modified in minfi.
 #
 # REQUIRES: quadprog
 #
 # ARGUMENTS:
-#      
-# Y:    A J x N matrix of methylation beta-values collected from 
+#
+# Y:    A J x N matrix of methylation beta-values collected from
 #       mixed/ heterogeneous biospecimen (i.e., WB).  Target set.
 #
-# coefWBC:    A J x K projection matrix;, i.e., within-cell type mean  
+# coefWBC:    A J x K projection matrix;, i.e., within-cell type mean
 #             methylation matrix across J DMLs and K many cell types
 #
-# contrastWBC: Contrast for cell composition predictions.  The user  
-#               needn't modify this 
+# contrastWBC: Contrast for cell composition predictions.  The user
+#               needn't modify this
 #
 # nonnegative: Should cell predictions be nonnegative.  Defaults to TRUE
 #
-# lessThanOne: Should the predictions be constrained to exactly one, 
+# lessThanOne: Should the predictions be constrained to exactly one,
 #                in minfi default is FALSE
 #
-# RETURNS:   A N x K matrix of cell proportion estimates across the K cell 
+# RETURNS:   A N x K matrix of cell proportion estimates across the K cell
 #            types for each of the N subjects contained in the Target Set.
-#    
+#
 ###############################################################################
-projectCellType <- function(Y, coefCellType, contrastCellType=NULL, 
-                    nonnegative=TRUE, lessThanOne=lessThanOne){ 
+projectCellType <- function(Y, coefCellType, contrastCellType=NULL,
+                    nonnegative=TRUE, lessThanOne=lessThanOne){
     if(is.null(contrastCellType))
         Xmat <- coefCellType
     else
-        Xmat <- tcrossprod(coefCellType, contrastCellType) 
+        Xmat <- tcrossprod(coefCellType, contrastCellType)
     nCol <- dim(Xmat)[2]
     if(nCol == 2) {
         Dmat <- crossprod(Xmat)
@@ -719,14 +719,14 @@ projectCellType <- function(Y, coefCellType, contrastCellType=NULL,
                 b0vec <- rep(0, nCol)
             }
             for(i in seq_len(nSubj)) {
-                obs <- which(!is.na(Y[,i])) 
+                obs <- which(!is.na(Y[,i]))
                 Dmat <- crossprod(Xmat[obs,])
-                mixCoef[i,] <- solve.QP(Dmat, crossprod(Xmat[obs,], Y[obs,i]), 
+                mixCoef[i,] <- solve.QP(Dmat, crossprod(Xmat[obs,], Y[obs,i]),
                                         Amat, b0vec)$sol
             }
         } else {
             for(i in seq_len(nSubj)) {
-                obs <- which(!is.na(Y[,i])) 
+                obs <- which(!is.na(Y[,i]))
                 Dmat <- crossprod(Xmat[obs,])
                 mixCoef[i,] <- solve(Dmat, t(Xmat[obs,]) %*% Y[obs,i])
             }
@@ -743,8 +743,8 @@ validationCellType <- function(Y, pheno, modelFix, modelBatch=NULL,
     M <- dim(Y)[1]
     if(is.null(L.forFstat)) {
         L.forFstat <- diag(sizeModel)[-1,] # All non-intercept coefficients
-        colnames(L.forFstat) <- colnames(xTest) 
-        rownames(L.forFstat) <- colnames(xTest)[-1] 
+        colnames(L.forFstat) <- colnames(xTest)
+        rownames(L.forFstat) <- colnames(xTest)[-1]
     }
     # Initialize various containers
     sigmaResid <- sigmaIcept <- nObserved <- nClusters <- Fstat <- rep(NA, M)
@@ -760,22 +760,22 @@ validationCellType <- function(Y, pheno, modelFix, modelBatch=NULL,
 
         if(j%%round(M/10)==0 && verbose)
             cat(".") # Report progress
-        
+
         try({ # Try to fit a mixed model to adjust for plate
             if(!is.null(modelBatch)) {
                 fit <- try(lme(modelFix, random=modelBatch, data=pheno[ii,]))
-                OLS <- inherits(fit,"try-error") 
+                OLS <- inherits(fit,"try-error")
                 # If LME can't be fit, just use OLS
             } else
                 OLS <- TRUE
-            
+
             if(OLS) {
                 fit <- lm(modelFix, data=pheno[ii,])
                 fitCoef <- fit$coef
                 sigmaResid[j] <- summary(fit)$sigma
                 sigmaIcept[j] <- 0
                 nClusters[j] <- 0
-            } else { 
+            } else {
                 fitCoef <- fit$coef$fixed
                 sigmaResid[j] <- fit$sigma
                 sigmaIcept[j] <- sqrt(getVarCov(fit)[1])
@@ -783,7 +783,7 @@ validationCellType <- function(Y, pheno, modelFix, modelBatch=NULL,
             }
             coefEsts[j,] <- fitCoef
             coefVcovs[[j]] <- vcov(fit)
-            
+
             useCoef <- L.forFstat %*% fitCoef
             useV <- L.forFstat %*% coefVcovs[[j]] %*% t(L.forFstat)
             Fstat[j] <- (t(useCoef) %*% solve(useV, useCoef))/sizeModel
@@ -795,17 +795,17 @@ validationCellType <- function(Y, pheno, modelFix, modelBatch=NULL,
     rownames(coefEsts) <- rownames(Y)
     colnames(coefEsts) <- names(fitCoef)
     degFree <- nObserved - nClusters - sizeModel + 1
-    
+
     ## Get P values corresponding to F statistics
     Pval <- 1-pf(Fstat, sizeModel, degFree)
-    
-    out <- list(coefEsts=coefEsts, coefVcovs=coefVcovs, modelFix=modelFix, 
+
+    out <- list(coefEsts=coefEsts, coefVcovs=coefVcovs, modelFix=modelFix,
                 modelBatch=modelBatch,
-                sigmaIcept=sigmaIcept, sigmaResid=sigmaResid, 
+                sigmaIcept=sigmaIcept, sigmaResid=sigmaResid,
                 L.forFstat=L.forFstat, Pval=Pval,
-                orderFstat=order(-Fstat), Fstat=Fstat, nClusters=nClusters, 
+                orderFstat=order(-Fstat), Fstat=Fstat, nClusters=nClusters,
                 nObserved=nObserved,
                 degFree=degFree)
-    
+
     out
 }

--- a/R/estimateCellCounts2.R
+++ b/R/estimateCellCounts2.R
@@ -1,6 +1,6 @@
-#' estimateCellCounts2
-#' @description
-#' estimateCellCounts2 function allows the use of customized reference
+#' estimateCellCounts2 
+#' @description 
+#' estimateCellCounts2 function allows the use of customized reference   
 #' datasets and IDOL probes L-DMR lists
 #' @import minfi
 #' @import SummarizedExperiment
@@ -24,91 +24,91 @@
 #' @importFrom nlme getVarCov
 #' @examples
 #' # Step 1: Load the reference library to extract the artificial mixtures
-#'
+#' 
 #' library(ExperimentHub)
 #' hub <- ExperimentHub()
 #' query(hub, "FlowSorted.Blood.EPIC")
 #' FlowSorted.Blood.EPIC <- hub[["EH1136"]]
 #' FlowSorted.Blood.EPIC
-#'
-#' # Step 2 separate the reference from the testing dataset if you want to run
+#' 
+#' # Step 2 separate the reference from the testing dataset if you want to run 
 #' # examples for estimations for this function example
-#'
+#' 
 #' RGsetTargets <- FlowSorted.Blood.EPIC[,
 #'              FlowSorted.Blood.EPIC$CellType == "MIX"]
-#'
+#'              
 #' sampleNames(RGsetTargets) <- paste(RGsetTargets$CellType,
 #'                             seq_len(dim(RGsetTargets)[2]), sep = "_")
 #' RGsetTargets
-#'
+#' 
 #' # Step 3: use your favorite package for deconvolution.
-#' # Deconvolute a target data set consisting of EPIC DNA methylation
+#' # Deconvolute a target data set consisting of EPIC DNA methylation 
 #' # data profiled in blood, using your prefered method.
-#'
+#' 
 #' # You can use our IDOL optimized DMR library for the EPIC array.  This object
 #' # contains a vector of length 450 consisting of the IDs of the IDOL optimized
 #' # CpG probes.  These CpGs are used as the backbone for deconvolution and were
-#' # selected because their methylation signature differs across the six normal
+#' # selected because their methylation signature differs across the six normal 
 #' # leukocyte subtypes.
-#'
+#' 
 #' data (IDOLOptimizedCpGs)
 #' head (IDOLOptimizedCpGs)
-#' # If you need to deconvolute a 450k legacy dataset use
+#' # If you need to deconvolute a 450k legacy dataset use 
 #' # IDOLOptimizedCpGs450klegacy instead
-#'
-#' # We recommend using Noob processMethod = "preprocessNoob" in minfi for the
-#' # target and reference datasets.
+#' 
+#' # We recommend using Noob processMethod = "preprocessNoob" in minfi for the 
+#' # target and reference datasets. 
 #' # Cell types included are "CD8T", "CD4T", "NK", "Bcell", "Mono", "Neu"
-#'
-#' # To use the IDOL optimized list of CpGs (IDOLOptimizedCpGs) use
-#' # estimateCellCounts2 an adaptation of the popular estimateCellCounts in
-#' # minfi. This function also allows including customized reference arrays.
-#'
-#' # Do not run with limited RAM the normalization step requires a big amount
+#' 
+#' # To use the IDOL optimized list of CpGs (IDOLOptimizedCpGs) use 
+#' # estimateCellCounts2 an adaptation of the popular estimateCellCounts in 
+#' # minfi. This function also allows including customized reference arrays. 
+#' 
+#' # Do not run with limited RAM the normalization step requires a big amount 
 #' # of memory resources
-#'
+#' 
 #' if (memory.limit()>8000){
-#'  countsEPIC<-estimateCellCounts2(RGsetTargets, compositeCellType = "Blood",
+#'  countsEPIC<-estimateCellCounts2(RGsetTargets, compositeCellType = "Blood", 
 #'                                 processMethod = "preprocessNoob",
-#'                                 probeSelect = "IDOL",
-#'                                 cellTypes = c("CD8T", "CD4T", "NK", "Bcell",
-#'                                 "Mono", "Neu"),
-#'                                 referencePlatform =
+#'                                 probeSelect = "IDOL", 
+#'                                 cellTypes = c("CD8T", "CD4T", "NK", "Bcell", 
+#'                                 "Mono", "Neu"), 
+#'                                 referencePlatform = 
 #'                                 "IlluminaHumanMethylationEPIC",
 #'                                 referenceset = NULL,
-#'                                 IDOLOptimizedCpGs =IDOLOptimizedCpGs,
+#'                                 IDOLOptimizedCpGs =IDOLOptimizedCpGs, 
 #'                                 returnAll = FALSE)
-#'
+#'                                 
 #' head(countsEPIC$counts)
 #' }
-#'
+#' 
 #' # CIBERSORT and/or RPC deconvolution
 #' # If you prefer CIBERSORT or RPC deconvolution use EpiDISH or similar
-#'
+#' 
 #' # Example not to run
-#'
-#' # countsEPIC<-estimateCellCounts2(RGsetTargets, compositeCellType = "Blood",
+#' 
+#' # countsEPIC<-estimateCellCounts2(RGsetTargets, compositeCellType = "Blood", 
 #' #                                processMethod = "preprocessNoob",
-#' #                                probeSelect = "IDOL",
-#' #                                cellTypes = c("CD8T", "CD4T", "NK",
-#' #                                "Bcell", "Mono", "Neu"),
-#' #                                referencePlatform =
+#' #                                probeSelect = "IDOL", 
+#' #                                cellTypes = c("CD8T", "CD4T", "NK", 
+#' #                                "Bcell", "Mono", "Neu"), 
+#' #                                referencePlatform = 
 #' #                                "IlluminaHumanMethylationEPIC",
 #' #                                referenceset = NULL,
-#' #                                IDOLOptimizedCpGs =IDOLOptimizedCpGs,
+#' #                                IDOLOptimizedCpGs =IDOLOptimizedCpGs, 
 #' #                                returnAll = TRUE)
-#'
+#' 
 #' # library(EpiDISH)
-#' # RPC <- epidish(getBeta(countsEPIC2$normalizedData),
+#' # RPC <- epidish(getBeta(countsEPIC2$normalizedData), 
 #' # as.matrix(countsEPIC2$compTable[IDOLOptimizedCpGs, 3:8]), method = "RPC")
 #' # RPC$estF#RPC count estimates
-#'
-#' # CBS <- epidish(getBeta(countsEPIC2$normalizedData),
+#' 
+#' # CBS <- epidish(getBeta(countsEPIC2$normalizedData), 
 #' # as.matrix(countsEPIC2$compTable[IDOLOptimizedCpGs, 3:8]), method = "CBS")
 #' # CBS$estF#CBS count estimates
-#'
+#' 
 #' # UMBILICAL CORD BLOOD DECONVOLUTION
-#'
+#' 
 #' # Do not run
 #' # library (FlowSorted.Blood.EPIC)
 #' # data("IDOLOptimizedCpGsCordBlood")
@@ -118,204 +118,200 @@
 #' # myfiles <- query(hub, "FlowSorted.CordBloodCombined.450k")
 #' # FlowSorted.CordBloodCombined.450k <- myfiles[[1]]
 #' # FlowSorted.CordBloodCombined.450k
-#'
-#' # Step 2 separate the reference from the testing dataset if you want to run
+#' 
+#' # Step 2 separate the reference from the testing dataset if you want to run 
 #' # examples for estimations for this function example
-#'
+#' 
 #' # RGsetTargets <- FlowSorted.CordBloodCombined.450k[,
 #' # FlowSorted.CordBloodCombined.450k$CellType == "WBC"]
 #' # sampleNames(RGsetTargets) <- paste(RGsetTargets$CellType,
 #' #                               seq_len(dim(RGsetTargets)[2]), sep = "_")
 #' # RGsetTargets
-#'
+#' 
 #' # Step 3: use your favorite package for deconvolution.
-#' # Deconvolute a target data set consisting of 450K DNA methylation
+#' # Deconvolute a target data set consisting of 450K DNA methylation 
 #' # data profiled in blood, using your prefered method.
 #' # You can use our IDOL optimized DMR library for the Cord Blood,  This object
 #' # contains a vector of length 517 consisting of the IDs of the IDOL optimized
 #' # CpG probes.  These CpGs are used as the backbone for deconvolution and were
-#' # selected because their methylation signature differs across the six normal
+#' # selected because their methylation signature differs across the six normal 
 #' # leukocyte subtypes plus the nucleated red blood cells.
-#'
+#' 
 #' # data (IDOLOptimizedCpGsCordBlood)
 #' # head (IDOLOptimizedCpGsCordBlood)
-#' # We recommend using Noob processMethod = "preprocessNoob" in minfi for the
-#' # target and reference datasets.
-#' # Cell types included are "CD8T", "CD4T", "NK", "Bcell", "Mono", "Gran",
+#' # We recommend using Noob processMethod = "preprocessNoob" in minfi for the 
+#' # target and reference datasets. 
+#' # Cell types included are "CD8T", "CD4T", "NK", "Bcell", "Mono", "Gran", 
 #' # "nRBC"
-#' # To use the IDOL optimized list of CpGs (IDOLOptimizedCpGsCordBlood) use
-#' # estimateCellCounts2 from FlowSorted.Blood.EPIC.
-#' # Do not run with limited RAM the normalization step requires a big amount
-#' # of memory resources. Use the parameters as specified below for
+#' # To use the IDOL optimized list of CpGs (IDOLOptimizedCpGsCordBlood) use 
+#' # estimateCellCounts2 from FlowSorted.Blood.EPIC. 
+#' # Do not run with limited RAM the normalization step requires a big amount 
+#' # of memory resources. Use the parameters as specified below for 
 #' # reproducibility.
-#' #
+#' # 
 #' # if (memory.limit()>8000){
-#' #     countsUCB<-estimateCellCounts2(RGsetTargets,
-#' #                                     compositeCellType =
-#' #                                                "CordBloodCombined",
+#' #     countsUCB<-estimateCellCounts2(RGsetTargets, 
+#' #                                     compositeCellType = 
+#' #                                                "CordBloodCombined", 
 #' #                                     processMethod = "preprocessNoob",
-#' #                                     probeSelect = "IDOL",
-#' #                                     cellTypes = c("CD8T", "CD4T", "NK",
-#' #                                     "Bcell", "Mono", "Gran", "nRBC"),
-#' #                                     referencePlatform =
+#' #                                     probeSelect = "IDOL", 
+#' #                                     cellTypes = c("CD8T", "CD4T", "NK",  
+#' #                                     "Bcell", "Mono", "Gran", "nRBC"), 
+#' #                                     referencePlatform = 
 #' #                                         "IlluminaHumanMethylation450k",
-#' #                                     referenceset =
+#' #                                     referenceset = 
 #' #                                      "FlowSorted.CordBloodCombined.450k",
 #' #                                     IDOLOptimizedCpGs =
-#' #                                       IDOLOptimizedCpGsCordBlood,
+#' #                                       IDOLOptimizedCpGsCordBlood, 
 #' #                                     returnAll = FALSE)
-#' #
+#' #     
 #' #     head(countsUCB$counts)
 #' # }
-#'
-#' @references LA Salas et al. (2018). \emph{An optimized library for
-#' reference-based deconvolution of whole-blood biospecimens assayed using the
+#' 
+#' @references LA Salas et al. (2018). \emph{An optimized library for 
+#' reference-based deconvolution of whole-blood biospecimens assayed using the 
 #' Illumina HumanMethylationEPIC BeadArray}. Genome Biology 19, 64. doi:
-#' \href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}
-#' @references DC Koestler et al. (2016). \emph{Improving cell mixture
-#' deconvolution by identifying optimal DNA methylation libraries (IDOL)}.
-#' BMC bioinformatics. 17, 120. doi:
-#' \href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}.
-#' @references EA Houseman, et al.(2012)  \emph{DNA methylation arrays as
-#' surrogate measures of cell mixture distribution}. BMC bioinformatics  13:86.
-#' doi:\href{https://dx.doi.org/10.1186/s12859-016-0943-7}{10.1186/1471-2105-13-86}.
-#' @references AE Jaffe and RA Irizarry.(2014) \emph{Accounting for cellular
-#' heterogeneity is critical in epigenome-wide association studies}.
-#' Genome Biology  15:R31. doi:
-#' \href{https://dx.doi.org/10.1186/gb-2014-15-2-r31}{10.1186/gb-2014-15-2-r31}.
-#' @references K Gervin, LA Salas et al. (2019) \emph{Systematic evaluation and
-#' validation of references and library selection methods for deconvolution of
+#' 10.1186/s13059-018-1448-7.
+#' @references DC Koestler et al. (2016). \emph{Improving cell mixture 
+#' deconvolution by identifying optimal DNA methylation libraries (IDOL)}. 
+#' BMC bioinformatics. 17, 120. doi: 10.1186/s12859-016-0943-7.
+#' @references EA Houseman, et al.(2012)  \emph{DNA methylation arrays as 
+#' surrogate measures of cell mixture distribution}. BMC bioinformatics  13:86. 
+#' doi:10.1186/1471-2105-13-86.
+#' @references AE Jaffe and RA Irizarry.(2014) \emph{Accounting for cellular 
+#' heterogeneity is critical in epigenome-wide association studies}. 
+#' Genome Biology  15:R31. doi:10.1186/gb-2014-15-2-r31.
+#' @references K Gervin, LA Salas et al. (2019) \emph{Systematic evaluation and 
+#' validation of references and library selection methods for deconvolution of 
 #' cord blood DNA methylation data}. Clin Epigenetics 11,125. doi:
-#' \href{https://dx.doi.org/10.1186/s13148-019-0717-y}{10.1186/s13148-019-0717-y}.
-#' @references KM Bakulski, et al. (2016) \emph{DNA methylation of cord blood
-#' cell types: Applications for mixed cell birth studies}. Epigenetics 11:5.
-#' doi:\href{https://dx.doi.org/10.1080/15592294.2016.1161875}{10.1080/15592294.2016.1161875}.
-#' @references AJ Titus, et al. (2017). \emph{Cell-type deconvolution from DNA
+#' 10.1186/s13148-019-0717-y
+#' @references KM Bakulski, et al. (2016) \emph{DNA methylation of cord blood 
+#' cell types: Applications for mixed cell birth studies}. Epigenetics 11:5. 
+#' doi:10.1080/15592294.2016.1161875.
+#' @references AJ Titus, et al. (2017). \emph{Cell-type deconvolution from DNA 
 #' methylation: a review of recent applications}. Hum Mol Genet 26: R216-R224.
-#' doi:\href{https://dx.doi.org/10.1093/hmg/ddx275}{10.1093/hmg/ddx275}
-#' @references AE Teschendorff, et al. (2017). \emph{A comparison of
-#' reference-based algorithms for correcting cell-type heterogeneity in
-#' Epigenome-Wide Association Studies}. BMC Bioinformatics 18: 105. doi:
-#' \href{https://dx.doi.org/10.1186/s12859-017-1511-5}{10.1186/s12859-017-1511-5}
-#' @param
+#' @references AE Teschendorff, et al. (2017). \emph{A comparison of 
+#' reference-based algorithms for correcting cell-type heterogeneity in 
+#' Epigenome-Wide Association Studies}. BMC Bioinformatics 18: 105.
+#' @param 
 #' rgSet           The input RGChannelSet or raw MethylSet for the procedure.
 #' @param
-#' compositeCellType   Which composite cell type is being deconvoluted.
+#' compositeCellType   Which composite cell type is being deconvoluted. 
 #'                      Should be one of "Blood", "CordBloodCombined",
 #'                      "CordBlood", "CordBloodNorway", "CordTissueAndBlood",
 #'                      or "DLPFC".
 #'                      See details for preferred approaches.
 #' @param
-#' processMethod Joint normalization/background correction for user and
-#'                reference data
-#'
-#'                Default input, "preprocessNoob" in minfi, you can use "auto"
-#'                for preprocessQuantile for Blood and DLPFC in 450K datasets
-#'                and preprocessNoob otherwise, according to existing
-#'                literature.
-#'
-#'                For MethylSet objects only "preprocessQuantile"
-#'                is available. Set it to any minfi preprocessing function as a
-#'                character if you want to override it, like
+#' processMethod Joint normalization/background correction for user and 
+#'                reference data 
+#'                
+#'                Default input, "preprocessNoob" in minfi, you can use "auto" 
+#'                for preprocessQuantile for Blood and DLPFC in 450K datasets 
+#'                and preprocessNoob otherwise, according to existing 
+#'                literature. 
+#'                
+#'                For MethylSet objects only "preprocessQuantile"  
+#'                is available. Set it to any minfi preprocessing function as a 
+#'                character if you want to override it, like 
 #'                "preprocessFunnorm"
-#' @param
-#' probeSelect    How should probes be selected to distinguish cell types?
-#'
+#' @param 
+#' probeSelect    How should probes be selected to distinguish cell types? 
+#' 
 #'                Options include:
 #'                1)  "IDOL", for using a customized set of probes obtained from
-#'                 IDOL optimization, available for Blood and Umbilical Cord
-#'                 Blood
-#'                2) "both", which selects an equal number (50) of probes (with
-#'                F-stat p-value < 1E-8) with the greatest magnitude of effect
-#'                from the hyper- and hypo-methylated sides, and
-#'                3) "any", which selects the 100 probes (with F-stat p-value
-#'                < 1E-8) with the greatest magnitude of difference regardless
-#'                of direction of effect.
-#'
-#'
-#'                This according to minfi algorithm. Default input "auto" in
-#'                minfi will use "any" for cord blood and "both" otherwise.
+#'                 IDOL optimization, available for Blood and Umbilical Cord 
+#'                 Blood 
+#'                2) "both", which selects an equal number (50) of probes (with 
+#'                F-stat p-value < 1E-8) with the greatest magnitude of effect 
+#'                from the hyper- and hypo-methylated sides, and 
+#'                3) "any", which selects the 100 probes (with F-stat p-value 
+#'                < 1E-8) with the greatest magnitude of difference regardless 
+#'                of direction of effect.  
+#'                
+#'                
+#'                This according to minfi algorithm. Default input "auto" in  
+#'                minfi will use "any" for cord blood and "both" otherwise.  
 #'                Please see references for more details.
-#' @param
-#' cellTypes     A vector of length K that contains the cell type names.
+#' @param 
+#' cellTypes     A vector of length K that contains the cell type names.  
 #'                Default: c("CD8T", "CD4T", "NK", "Bcell", "Mono", "Neu").
-#'                Please notice that this library use Neutrophils instead
+#'                Please notice that this library use Neutrophils instead 
 #'                of Granulocytes. See details for your library.
-#' @param
-#' referencePlatform The platform for the reference dataset; if the input
-#'                    rgSet belongs to another platform, it will be converted
+#' @param                 
+#' referencePlatform The platform for the reference dataset; if the input  
+#'                    rgSet belongs to another platform, it will be converted  
 #'                    using minfi function convertArray.
 #' @param
-#' referenceset It is NULL by default.
-#'
-#'             A custom reference RGChannelSet object (in quotes) if it is not
+#' referenceset It is NULL by default.  
+#'             
+#'             A custom reference RGChannelSet object (in quotes) if it is not 
 #'             a package installed. This option also allows the user to perform
 #'             the deconvolution in closed computing clusters without internet
-#'             access to ExperimentHub. For that download and save the
-#'             reference and input the resulting object here. If using an
+#'             access to ExperimentHub. For that download and save the 
+#'             reference and input the resulting object here. If using an 
 #'             installed reference package set to NULL.
 #' @param
-#' IDOLOptimizedCpGs a vector of probe names for cell deconvolution. For
-#'                 EPIC datasets it should be equal to IDOLOptimizedCpGs (no
-#'                 quotes). For legacy 450K datasets you can use
-#'                 IDOLOptimizedCpGs450klegacy (no quotes) if you want to use
+#' IDOLOptimizedCpGs a vector of probe names for cell deconvolution. For 
+#'                 EPIC datasets it should be equal to IDOLOptimizedCpGs (no 
+#'                 quotes). For legacy 450K datasets you can use 
+#'                 IDOLOptimizedCpGs450klegacy (no quotes) if you want to use 
 #'                 FlowSorted.EPIC.Blood for the deconvolution. For umbilical
-#'                 cord blood use IDOLOptimizedCpGsCordBlood in the
+#'                 cord blood use IDOLOptimizedCpGsCordBlood in the 
 #'                 FlowSorted.CordBloodCombined.450k package for both 450k and
 #'                 EPIC arrays. See details in help for each IDOL list.
-#' @param
-#' returnAll    Should the composition table and the normalized user supplied
+#' @param 
+#' returnAll    Should the composition table and the normalized user supplied 
 #'              data be return? Default is False.
-#' @param
+#' @param              
 #' verbose Should the function be verbose?
 #' @param
-#' meanPlot    Whether to plots the average DNA methylation across the
-#'             cell-type discriminating probes within the mixed and sorted
+#' meanPlot    Whether to plots the average DNA methylation across the  
+#'             cell-type discriminating probes within the mixed and sorted 
 #'             samples.
-#' @param
-#' lessThanOne Should the predictions be constrained to exactly one,
+#' @param 
+#' lessThanOne Should the predictions be constrained to exactly one, 
 #'             in minfi default is FALSE, now you can select the option
-#' @param
+#' @param 
 #' ...  Other arguments for preprocessquantile or other normalizations
 #'@return
-#' This function will return a list containing matrix of cell counts (counts),
-#' if returnAll=FALSE, or a list containing the counts, mean methylation per
-#' cellType, and the normalized betas (if returnAll is set to TRUE). These
-#' objects are important if you decide to use a different deconvolution
+#' This function will return a list containing matrix of cell counts (counts), 
+#' if returnAll=FALSE, or a list containing the counts, mean methylation per 
+#' cellType, and the normalized betas (if returnAll is set to TRUE). These 
+#' objects are important if you decide to use a different deconvolution 
 #' algorithm such as CIBERSORT or robust partial correlation (RPC).
 #' @export
-estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
-                                processMethod = "preprocessNoob",
-                                probeSelect = c("auto", "any", "IDOL"),
-                                cellTypes = c("CD8T", "CD4T", "NK", "Bcell",
-                                                "Mono", "Neu"),
-                        referencePlatform = c("IlluminaHumanMethylation450k",
-                                                "IlluminaHumanMethylationEPIC",
-                                                "IlluminaHumanMethylation27k"),
-                                referenceset = NULL, IDOLOptimizedCpGs = NULL,
-                                returnAll = FALSE, meanPlot = FALSE,
+estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood", 
+                                processMethod = "preprocessNoob", 
+                                probeSelect = c("auto", "any", "IDOL"), 
+                                cellTypes = c("CD8T", "CD4T", "NK", "Bcell", 
+                                                "Mono", "Neu"), 
+                        referencePlatform = c("IlluminaHumanMethylation450k", 
+                                                "IlluminaHumanMethylationEPIC", 
+                                                "IlluminaHumanMethylation27k"), 
+                                referenceset = NULL, IDOLOptimizedCpGs = NULL, 
+                                returnAll = FALSE, meanPlot = FALSE, 
                                 verbose = TRUE, lessThanOne = FALSE,
                                 ...) {
-    if ((!is(rgSet, "RGChannelSet")) && (!is(rgSet, "MethylSet")))
-        stop(strwrap(sprintf("object is of class '%s', but needs to be of
-                                class 'RGChannelSet' 'RGChannelSetExtended' or
-                                'MethylSet' to use this function",
-                            class(rgSet)), width = 80, prefix = " ",
+    if ((!is(rgSet, "RGChannelSet")) && (!is(rgSet, "MethylSet")))  
+        stop(strwrap(sprintf("object is of class '%s', but needs to be of 
+                                class 'RGChannelSet' 'RGChannelSetExtended' or 
+                                'MethylSet' to use this function", 
+                            class(rgSet)), width = 80, prefix = " ", 
                     initial = ""))
-    if (!is(rgSet, "RGChannelSet") &&
-        (processMethod[1] != "preprocessQuantile"))
-        stop(strwrap(sprintf("object is of class '%s', but needs to be of
-                                class 'RGChannelSet' or 'RGChannelSetExtended'
-                                to use other methods different to
+    if (!is(rgSet, "RGChannelSet") && 
+        (processMethod[1] != "preprocessQuantile")) 
+        stop(strwrap(sprintf("object is of class '%s', but needs to be of 
+                                class 'RGChannelSet' or 'RGChannelSetExtended' 
+                                to use other methods different to 
                                 'preprocessQuantile'", class(rgSet)),
                     width = 80, prefix = " ", initial = ""))
-    if (is(rgSet, "MethylSet") &&
-        (processMethod[1] == "preprocessQuantile"))
+    if (is(rgSet, "MethylSet") && 
+        (processMethod[1] == "preprocessQuantile")) 
         message(strwrap("[estimateCellCounts2] The function will assume that
-                            no preprocessing has been performed. Using
-                            'preprocessQuantile' in prenormalized data is
-                            experimental and it should only be run under the
-                            user responsibility",width = 80, prefix = " ",
+                            no preprocessing has been performed. Using 
+                            'preprocessQuantile' in prenormalized data is 
+                            experimental and it should only be run under the 
+                            user responsibility",width = 80, prefix = " ", 
                         initial = ""))
     if (is(rgSet, "RGChannelSetExtended"))
         rgSet <- as(rgSet, "RGChannelSet")
@@ -323,39 +319,39 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
     rgPlatform <- sub("IlluminaHumanMethylation", "",
                 annotation(rgSet)[which(names(annotation(rgSet)) == "array")])
     platform <- sub("IlluminaHumanMethylation", "", referencePlatform)
-    if ((compositeCellType == "CordBlood" |
-        compositeCellType == "CordBloodCombined") && (!"nRBC" %in% cellTypes))
-        message(strwrap("[estimateCellCounts2] Consider including 'nRBC' in
+    if ((compositeCellType == "CordBlood" | 
+        compositeCellType == "CordBloodCombined") && (!"nRBC" %in% cellTypes)) 
+        message(strwrap("[estimateCellCounts2] Consider including 'nRBC' in 
                         argument 'cellTypes' for cord blood estimation.\n",
                         width = 80, prefix = " ", initial = ""))
-    if ((compositeCellType == "Blood") &&
-        (referencePlatform == "IlluminaHumanMethylationEPIC") &&
-        ("Gran" %in% cellTypes))
-        message(strwrap("[estimateCellCounts2] Replace 'Gran' for 'Neu' in
+    if ((compositeCellType == "Blood") && 
+        (referencePlatform == "IlluminaHumanMethylationEPIC") && 
+        ("Gran" %in% cellTypes)) 
+        message(strwrap("[estimateCellCounts2] Replace 'Gran' for 'Neu' in 
                         argument 'cellTypes' for EPIC blood estimation.\n",
                         width = 80, prefix = " ", initial = ""))
-    if ((compositeCellType != "Blood") &&
-        ("Neu" %in% cellTypes))
-        message(strwrap("[estimateCellCounts2] Check whether 'Gran' or 'Neu' is
-                        present in your reference and adjust argument
+    if ((compositeCellType != "Blood") && 
+        ("Neu" %in% cellTypes)) 
+        message(strwrap("[estimateCellCounts2] Check whether 'Gran' or 'Neu' is 
+                        present in your reference and adjust argument 
                         'cellTypes' for your estimation.\n",
                         width = 80, prefix = " ", initial = ""))
     if (compositeCellType == "CordBloodCombined")
-        platform <- "450k"
+        platform<="450k"
     referencePkg <- sprintf("FlowSorted.%s.%s", compositeCellType, platform)
     subverbose <- max(as.integer(verbose) - 1L, 0L)
     if (!is.null(referenceset)){
         referenceRGset<- get(referenceset)
         if (!is(rgSet, "RGChannelSet"))
             referenceRGset<-preprocessRaw(referenceRGset)
-    } else{
-        if (!require(referencePkg, character.only = TRUE))
-            stop(strwrap(sprintf("Could not find reference data package for
-                                compositeCellType '%s' and referencePlatform
-                                '%s' (inferred package name is '%s')",
+    } else{ 
+        if (!require(referencePkg, character.only = TRUE)) 
+            stop(strwrap(sprintf("Could not find reference data package for 
+                                compositeCellType '%s' and referencePlatform 
+                                '%s' (inferred package name is '%s')", 
                                 compositeCellType, platform, referencePkg),
                         width = 80, prefix = " ", initial = ""))
-        if((referencePkg!="FlowSorted.Blood.EPIC")  &&
+        if((referencePkg!="FlowSorted.Blood.EPIC")  && 
             (referencePkg!="FlowSorted.CordBloodCombined.450k")){
             referenceRGset <- get(referencePkg)
         } else if (referencePkg=="FlowSorted.Blood.EPIC"){
@@ -363,108 +359,83 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
             referenceRGset <-hub[["EH1136"]]
         } else if (referencePkg=="FlowSorted.CordBloodCombined.450k"){
             hub <- ExperimentHub()
-            referenceRGset <-hub[["EH2256"]]
+            referenceRGset <-hub[["EH2256"]]            
         }
         if (!is(rgSet, "RGChannelSet"))
-            referenceRGset<-preprocessRaw(referenceRGset)
-    }
+            referenceRGset<-preprocessRaw(referenceRGset) 
+    }   
     if (rgPlatform != platform) {
-        rgSet <- convertArray(rgSet, outType = referencePlatform,
+        rgSet <- convertArray(rgSet, outType = referencePlatform, 
                                 verbose = TRUE)
     }
-    if (!"CellType" %in% names(colData(referenceRGset)))
-        stop(strwrap(sprintf("the reference sorted dataset (in this case '%s')
-                            needs to have a phenoData column called
+    if (!"CellType" %in% names(colData(referenceRGset))) 
+        stop(strwrap(sprintf("the reference sorted dataset (in this case '%s') 
+                            needs to have a phenoData column called 
                             'CellType'"), names(referencePkg),
                     width = 80, prefix = " ", initial = ""))
-    if (sum(colnames(rgSet) %in% colnames(referenceRGset)) > 0)
-        stop(strwrap("the sample/column names in the user set must not be in
-                    the reference data ", width = 80, prefix = " ",
+    if (sum(colnames(rgSet) %in% colnames(referenceRGset)) > 0) 
+        stop(strwrap("the sample/column names in the user set must not be in 
+                    the reference data ", width = 80, prefix = " ", 
                     initial = ""))
-    if (!all(cellTypes %in% referenceRGset$CellType))
-        stop(strwrap(sprintf("all elements of argument 'cellTypes' needs to be
-                            part of the reference phenoData columns 'CellType'
-                            (containg the following elements: '%s')",
-                            paste(unique(referenceRGset$cellType),
-                                    collapse = "', '")), width = 80,
+    if (!all(cellTypes %in% referenceRGset$CellType)) 
+        stop(strwrap(sprintf("all elements of argument 'cellTypes' needs to be 
+                            part of the reference phenoData columns 'CellType' 
+                            (containg the following elements: '%s')", 
+                            paste(unique(referenceRGset$cellType), 
+                                    collapse = "', '")), width = 80, 
                     prefix = " ", initial = ""))
-    if (length(unique(cellTypes)) < 2)
+    if (length(unique(cellTypes)) < 2) 
         stop("At least 2 cell types must be provided.")
-    if ((processMethod == "auto") &&
-        (compositeCellType %in% c("Blood", "DLPFC")))
+    if ((processMethod == "auto") && 
+        (compositeCellType %in% c("Blood", "DLPFC"))) 
         processMethod <- "preprocessQuantile"
-    if ((processMethod == "auto") &&
-        (!compositeCellType %in% c("Blood","DLPFC")) &&
-        (is(rgSet, "RGChannelSet")))
+    if ((processMethod == "auto") && 
+        (!compositeCellType %in% c("Blood","DLPFC")) && 
+        (is(rgSet, "RGChannelSet"))) 
         processMethod <- "preprocessNoob"
     processMethod <- get(processMethod)
-    if ((probeSelect == "auto") &&
-        (compositeCellType %in% c("CordBloodCombined", "CordBlood",
+    if ((probeSelect == "auto") && 
+        (compositeCellType %in% c("CordBloodCombined", "CordBlood", 
                                     "CordBloodNorway", "CordTissueAndBlood"))) {
         probeSelect <- "any"
     }
-    if ((probeSelect == "auto") &&
-        (!compositeCellType %in% c("CordBloodCombined", "CordBlood",
+    if ((probeSelect == "auto") && 
+        (!compositeCellType %in% c("CordBloodCombined", "CordBlood", 
                                     "CordBloodNorway", "CordTissueAndBlood"))) {
         probeSelect <- "both"
     }
-    if (verbose)
-        message(strwrap("[estimateCellCounts2] Combining user data with
-                        reference (flow sorted) data.\n", width = 80,
+    if (verbose) 
+        message(strwrap("[estimateCellCounts2] Combining user data with 
+                        reference (flow sorted) data.\n", width = 80, 
                         prefix = " ", initial = ""))
-    newpd <- DataFrame(sampleNames = c(colnames(rgSet),
-                                        colnames(referenceRGset)),
-                        studyIndex = rep(c("user", "reference"),
-                                        times = c(ncol(rgSet),
+    newpd <- DataFrame(sampleNames = c(colnames(rgSet), 
+                                        colnames(referenceRGset)), 
+                        studyIndex = rep(c("user", "reference"), 
+                                        times = c(ncol(rgSet), 
                                                     ncol(referenceRGset))))
-    referenceRGset$CellType<-as.character(referenceRGset$CellType)
     if(is.null(rgSet$CellType))
         rgSet$CellType<-rep("NA", dim(rgSet)[2])
     if(is.null(rgSet$Age))
         rgSet$Age<-rep("NA", dim(rgSet)[2])
     if(is.null(rgSet$Sex))
         rgSet$Sex<-rep("NA", dim(rgSet)[2])
-    if(is.null(referenceRGset$Sex)){
-        referenceRGset$Sex<-rep("NA", dim(referenceRGset)[2])
-    }else{
-        referenceRGset$Sex<-as.character(referenceRGset$Sex)
-    }
-    if(is.null(referenceRGset$Age)){
-        referenceRGset$Age<-rep("NA", dim(referenceRGset)[2])
-    }else{
-        try(referenceRGset$Age<-as.numeric(referenceRGset$Age))
-    }
-    commoncolumn<-intersect(names(colData(rgSet)),
+    commoncolumn<-intersect(names(colData(rgSet)), 
                             names(colData(referenceRGset)))
-    restry<-try({colData(rgSet)[commoncolumn] <- mapply(FUN = as,
-                                        colData(rgSet)[commoncolumn],
-                                vapply(colData(referenceRGset)[commoncolumn],
+    colData(referenceRGset)[commoncolumn] <- mapply(FUN = as,
+                                        colData(referenceRGset)[commoncolumn],
+                                        vapply(colData(rgSet)[commoncolumn],
                                                 class, FUN.VALUE=character(1)),
-                                                    SIMPLIFY = FALSE)},
-                                                    silent = TRUE)
-    if ( "try-error" %in% class(restry) ) {
-        commoncolumn<-c("CellType", "Sex", "Age")
-        colData(rgSet)[commoncolumn] <- mapply(FUN = as,
-                                           colData(rgSet)[commoncolumn],
-                                vapply(colData(referenceRGset)[commoncolumn],
-                                                class, FUN.VALUE=character(1)),
-                                                    SIMPLIFY = FALSE)} else{
-    colData(rgSet)[commoncolumn] <- mapply(FUN = as,
-                                           colData(rgSet)[commoncolumn],
-                                vapply(colData(referenceRGset)[commoncolumn],
-                                                class, FUN.VALUE=character(1)),
-                                                    SIMPLIFY = FALSE)}
-    rm(restry)
+                                                    SIMPLIFY = FALSE)
     colData(referenceRGset)<-colData(referenceRGset)[commoncolumn]
     colData(rgSet)<-colData(rgSet)[commoncolumn]
     referencePd <- colData(referenceRGset)
-    combinedRGset <- combineArrays(rgSet, referenceRGset,
+    combinedRGset <- combineArrays(rgSet, referenceRGset, 
                                     outType = referencePlatform)
     colData(combinedRGset) <- newpd
     colnames(combinedRGset) <- newpd$sampleNames
     rm(referenceRGset)
-    if (verbose)
-        message(strwrap("[estimateCellCounts2] Processing user and reference
+    if (verbose) 
+        message(strwrap("[estimateCellCounts2] Processing user and reference 
                         data together.\n", width = 80, prefix = " ",
                         initial = ""))
     if (compositeCellType == "CordBlood") {
@@ -475,7 +446,7 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
         rm(combinedRGset)
         gc()
         compTable <- get(paste0(referencePkg, ".compTable"))
-        combinedMset <- combinedMset[which(rownames(combinedMset) %in%
+        combinedMset <- combinedMset[which(rownames(combinedMset) %in% 
                                                 rownames(compTable)), ]
     } else {
         if (!is(combinedRGset, "RGChannelSet"))
@@ -491,15 +462,15 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
     colData(mSet) <- as(colData(rgSet), "DataFrame")
     rm(combinedMset)
     if (probeSelect != "IDOL") {
-        if (verbose)
-            message(strwrap("[estimateCellCounts2] Picking probes for
-                            composition estimation.\n", width = 80,
+        if (verbose) 
+            message(strwrap("[estimateCellCounts2] Picking probes for 
+                            composition estimation.\n", width = 80, 
                             prefix = " ", initial = ""))
-        compData <- pickCompProbes(referenceMset, cellTypes = cellTypes,
-                                    compositeCellType = compositeCellType,
+        compData <- pickCompProbes(referenceMset, cellTypes = cellTypes, 
+                                    compositeCellType = compositeCellType, 
                                     probeSelect = probeSelect)
         coefs <- compData$coefEsts
-        if (verbose)
+        if (verbose) 
             message("[estimateCellCounts2] Estimating composition.\n")
         counts <- projectCellType(getBeta(mSet)[rownames(coefs), ], coefs,
                                 lessThanOne = lessThanOne)
@@ -507,32 +478,32 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
         if (meanPlot) {
             smeans <- compData$sampleMeans
             smeans <- smeans[order(names(smeans))]
-            sampleMeans <- c(colMeans(minfi::getBeta(mSet)[rownames(coefs), ]),
+            sampleMeans <- c(colMeans(minfi::getBeta(mSet)[rownames(coefs), ]), 
                             smeans)
-            sampleColors <- c(rep(1, ncol(mSet)), 1 +
+            sampleColors <- c(rep(1, ncol(mSet)), 1 + 
                                 as.numeric(factor(names(smeans))))
             plot(sampleMeans, pch = 21, bg = sampleColors)
-            legend("bottomleft", c("blood", levels(factor(names(smeans)))),
+            legend("bottomleft", c("blood", levels(factor(names(smeans)))), 
                     col = seq_len(7), pch = 15)
         }
         if (returnAll) {
-            list(counts = counts, compTable = compData$compTable,
+            list(counts = counts, compTable = compData$compTable, 
                 normalizedData = mSet)
         } else {
-            list(counts = counts)
+            list(counts = counts)  
         }
     } else {
-        if (verbose)
-            message(strwrap("[estimateCellCounts2] Using IDOL L-DMR probes for
-                            composition estimation.\n", width = 80,
+        if (verbose) 
+            message(strwrap("[estimateCellCounts2] Using IDOL L-DMR probes for 
+                            composition estimation.\n", width = 80, 
                             prefix = " ", initial = ""))
         p <- getBeta(referenceMset)
         pd <- as.data.frame(colData(referenceMset))
         rm(referenceMset)
         if (!is.null(cellTypes)) {
-            if (!all(cellTypes %in% pd$CellType))
-                stop(strwrap("elements of argument 'cellTypes' is not part of
-                            'referenceMset$CellType'", width = 80,
+            if (!all(cellTypes %in% pd$CellType)) 
+                stop(strwrap("elements of argument 'cellTypes' is not part of 
+                            'referenceMset$CellType'", width = 80, 
                             prefix = " ", initial = ""))
             keep <- which(pd$CellType %in% cellTypes)
             pd <- pd[keep, ]
@@ -546,7 +517,7 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
         r <- rowRanges(p)
         compTable <- cbind(ffComp, prof, r, abs(r[, 1] - r[, 2]))
         names(compTable)[1] <- "Fstat"
-        names(compTable)[c(-2, -1, 0) + ncol(compTable)] <- c("low",
+        names(compTable)[c(-2, -1, 0) + ncol(compTable)] <- c("low", 
                                                             "high", "range")
         tstatList <- lapply(tIndexes, function(i) {
             x <- rep(0, ncol(p))
@@ -558,7 +529,7 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
         p <- p[trainingProbes, ]
         pMeans <- colMeans(p)
         names(pMeans) <- pd$CellType
-        form <- as.formula(sprintf("y ~ %s - 1", paste(levels(pd$CellType),
+        form <- as.formula(sprintf("y ~ %s - 1", paste(levels(pd$CellType), 
                                                         collapse = "+")))
         phenoDF <- as.data.frame(model.matrix(~pd$CellType - 1))
         colnames(phenoDF) <- sub("^pd\\$CellType", "", colnames(phenoDF))
@@ -573,7 +544,7 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
         }
         compData<-list(coefEsts = coefEsts, compTable = compTable,
                         sampleMeans = pMeans)
-        if (verbose)
+        if (verbose) 
             message("[estimateCellCounts2] Estimating composition.\n")
         counts <- projectCellType(getBeta(mSet)[rownames(coefs), ], coefs,
                                 lessThanOne = lessThanOne)
@@ -582,46 +553,46 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
             smeans <- compData$sampleMeans
             smeans <- smeans[order(names(smeans))]
             sampleMeans <- c(colMeans(getBeta(mSet)[rownames(coefs), ]), smeans)
-            sampleColors <- c(rep(1, ncol(mSet)), 1 +
+            sampleColors <- c(rep(1, ncol(mSet)), 1 + 
                                 as.numeric(factor(names(smeans))))
             plot(sampleMeans, pch = 21, bg = sampleColors)
-            legend("bottomleft", c("blood", levels(factor(names(smeans)))),
+            legend("bottomleft", c("blood", levels(factor(names(smeans)))), 
                     col = seq_len(7), pch = 15)
         }
         if (returnAll) {
             list(counts = counts, compTable = compTable, normalizedData = mSet)
         } else {
-            list(counts = counts)
+            list(counts = counts)  
         }
     }
 }
 
-#These are minfi internal functions here they are called to keep the function
+#These are minfi internal functions here they are called to keep the function 
 #above running for the alternative selection ("auto" and "both")
-pickCompProbes <- function(mSet, cellTypes = NULL, numProbes = 50,
-                            compositeCellType = compositeCellType,
+pickCompProbes <- function(mSet, cellTypes = NULL, numProbes = 50, 
+                            compositeCellType = compositeCellType, 
                             probeSelect = probeSelect) {
     p <- getBeta(mSet)
     pd <- as.data.frame(colData(mSet))
     if(!is.null(cellTypes)) {
         if(!all(cellTypes %in% pd$CellType))
-            stop(strwrap("elements of argument 'cellTypes' are not part of
-                        'mSet$CellType'", width = 80, prefix = " ",
+            stop(strwrap("elements of argument 'cellTypes' are not part of 
+                        'mSet$CellType'", width = 80, prefix = " ", 
                         initial = ""))
         keep <- which(pd$CellType %in% cellTypes)
         pd <- pd[keep,]
         p <- p[,keep]
     }
-    ## make cell type a factor
+    ## make cell type a factor 
     pd$CellType <- factor(pd$CellType, levels = cellTypes)
     ffComp <- rowFtests(p, pd$CellType)
     tIndexes <- split(seq(along=pd$CellType), pd$CellType)
-    prof <- vapply(tIndexes, function(i) rowMeans(p[,i]),
+    prof <- vapply(tIndexes, function(i) rowMeans(p[,i]), 
                     FUN.VALUE=numeric(dim(p)[1]))
     r <- rowRanges(p)
     compTable <- cbind(ffComp, prof, r, abs(r[,1] - r[,2]))
     names(compTable)[1] <- "Fstat"
-    names(compTable)[c(-2,-1,0) + ncol(compTable)] <- c("low", "high", "range")
+    names(compTable)[c(-2,-1,0) + ncol(compTable)] <- c("low", "high", "range") 
     tstatList <- lapply(tIndexes, function(i) {
         x <- rep(0,ncol(p))
         x[i] <- 1
@@ -630,7 +601,7 @@ pickCompProbes <- function(mSet, cellTypes = NULL, numProbes = 50,
     if (probeSelect == "any"){
         probeList <- lapply(tstatList, function(x) {
             y <- x[x[,"p.value"] < 1e-8,]
-            yAny <- y[order(abs(y[,"dm"]), decreasing=TRUE),]
+            yAny <- y[order(abs(y[,"dm"]), decreasing=TRUE),]      
             c(rownames(yAny)[seq_len(numProbes*2)])
         })
     } else {
@@ -638,16 +609,16 @@ pickCompProbes <- function(mSet, cellTypes = NULL, numProbes = 50,
             y <- x[x[,"p.value"] < 1e-8,]
             yUp <- y[order(y[,"dm"], decreasing=TRUE),]
             yDown <- y[order(y[,"dm"], decreasing=FALSE),]
-            c(rownames(yUp)[seq_len(numProbes)],
+            c(rownames(yUp)[seq_len(numProbes)], 
                 rownames(yDown)[seq_len(numProbes)])
         })
     }
     trainingProbes <- unique(unlist(probeList))
     p <- p[trainingProbes,]
-
+    
     pMeans <- colMeans(p)
     names(pMeans) <- pd$CellType
-    form <- as.formula(sprintf("y ~ %s - 1", paste(levels(pd$CellType),
+    form <- as.formula(sprintf("y ~ %s - 1", paste(levels(pd$CellType), 
                                                     collapse="+")))
     phenoDF <- as.data.frame(model.matrix(~pd$CellType-1))
     colnames(phenoDF) <- sub("^pd\\$CellType", "", colnames(phenoDF))
@@ -658,7 +629,7 @@ pickCompProbes <- function(mSet, cellTypes = NULL, numProbes = 50,
         tmp <- validationCellType(Y = p, pheno = phenoDF, modelFix = form)
         coefEsts <- tmp$coefEsts
     }
-
+    
     out <- list(coefEsts = coefEsts, compTable = compTable,
                 sampleMeans = pMeans)
     return(out)
@@ -668,37 +639,37 @@ pickCompProbes <- function(mSet, cellTypes = NULL, numProbes = 50,
 ###############################################################################
 # FUNCTION:  projectCellType
 #    This function predicts the underlying cellular composition of heterogeneous
-#    tissue types (i.e., WB) using the constrained projection procedure
-#    described by Houseman et al., (2012) and modified in minfi.
+#    tissue types (i.e., WB) using the constrained projection procedure 
+#    described by Houseman et al., (2012) and modified in minfi.  
 #
 # REQUIRES: quadprog
 #
 # ARGUMENTS:
-#
-# Y:    A J x N matrix of methylation beta-values collected from
+#      
+# Y:    A J x N matrix of methylation beta-values collected from 
 #       mixed/ heterogeneous biospecimen (i.e., WB).  Target set.
 #
-# coefWBC:    A J x K projection matrix;, i.e., within-cell type mean
+# coefWBC:    A J x K projection matrix;, i.e., within-cell type mean  
 #             methylation matrix across J DMLs and K many cell types
 #
-# contrastWBC: Contrast for cell composition predictions.  The user
-#               needn't modify this
+# contrastWBC: Contrast for cell composition predictions.  The user  
+#               needn't modify this 
 #
 # nonnegative: Should cell predictions be nonnegative.  Defaults to TRUE
 #
-# lessThanOne: Should the predictions be constrained to exactly one,
+# lessThanOne: Should the predictions be constrained to exactly one, 
 #                in minfi default is FALSE
 #
-# RETURNS:   A N x K matrix of cell proportion estimates across the K cell
+# RETURNS:   A N x K matrix of cell proportion estimates across the K cell 
 #            types for each of the N subjects contained in the Target Set.
-#
+#    
 ###############################################################################
-projectCellType <- function(Y, coefCellType, contrastCellType=NULL,
-                    nonnegative=TRUE, lessThanOne=lessThanOne){
+projectCellType <- function(Y, coefCellType, contrastCellType=NULL, 
+                    nonnegative=TRUE, lessThanOne=lessThanOne){ 
     if(is.null(contrastCellType))
         Xmat <- coefCellType
     else
-        Xmat <- tcrossprod(coefCellType, contrastCellType)
+        Xmat <- tcrossprod(coefCellType, contrastCellType) 
     nCol <- dim(Xmat)[2]
     if(nCol == 2) {
         Dmat <- crossprod(Xmat)
@@ -719,14 +690,14 @@ projectCellType <- function(Y, coefCellType, contrastCellType=NULL,
                 b0vec <- rep(0, nCol)
             }
             for(i in seq_len(nSubj)) {
-                obs <- which(!is.na(Y[,i]))
+                obs <- which(!is.na(Y[,i])) 
                 Dmat <- crossprod(Xmat[obs,])
-                mixCoef[i,] <- solve.QP(Dmat, crossprod(Xmat[obs,], Y[obs,i]),
+                mixCoef[i,] <- solve.QP(Dmat, crossprod(Xmat[obs,], Y[obs,i]), 
                                         Amat, b0vec)$sol
             }
         } else {
             for(i in seq_len(nSubj)) {
-                obs <- which(!is.na(Y[,i]))
+                obs <- which(!is.na(Y[,i])) 
                 Dmat <- crossprod(Xmat[obs,])
                 mixCoef[i,] <- solve(Dmat, t(Xmat[obs,]) %*% Y[obs,i])
             }
@@ -743,8 +714,8 @@ validationCellType <- function(Y, pheno, modelFix, modelBatch=NULL,
     M <- dim(Y)[1]
     if(is.null(L.forFstat)) {
         L.forFstat <- diag(sizeModel)[-1,] # All non-intercept coefficients
-        colnames(L.forFstat) <- colnames(xTest)
-        rownames(L.forFstat) <- colnames(xTest)[-1]
+        colnames(L.forFstat) <- colnames(xTest) 
+        rownames(L.forFstat) <- colnames(xTest)[-1] 
     }
     # Initialize various containers
     sigmaResid <- sigmaIcept <- nObserved <- nClusters <- Fstat <- rep(NA, M)
@@ -760,22 +731,22 @@ validationCellType <- function(Y, pheno, modelFix, modelBatch=NULL,
 
         if(j%%round(M/10)==0 && verbose)
             cat(".") # Report progress
-
+        
         try({ # Try to fit a mixed model to adjust for plate
             if(!is.null(modelBatch)) {
                 fit <- try(lme(modelFix, random=modelBatch, data=pheno[ii,]))
-                OLS <- inherits(fit,"try-error")
+                OLS <- inherits(fit,"try-error") 
                 # If LME can't be fit, just use OLS
             } else
                 OLS <- TRUE
-
+            
             if(OLS) {
                 fit <- lm(modelFix, data=pheno[ii,])
                 fitCoef <- fit$coef
                 sigmaResid[j] <- summary(fit)$sigma
                 sigmaIcept[j] <- 0
                 nClusters[j] <- 0
-            } else {
+            } else { 
                 fitCoef <- fit$coef$fixed
                 sigmaResid[j] <- fit$sigma
                 sigmaIcept[j] <- sqrt(getVarCov(fit)[1])
@@ -783,7 +754,7 @@ validationCellType <- function(Y, pheno, modelFix, modelBatch=NULL,
             }
             coefEsts[j,] <- fitCoef
             coefVcovs[[j]] <- vcov(fit)
-
+            
             useCoef <- L.forFstat %*% fitCoef
             useV <- L.forFstat %*% coefVcovs[[j]] %*% t(L.forFstat)
             Fstat[j] <- (t(useCoef) %*% solve(useV, useCoef))/sizeModel
@@ -795,17 +766,17 @@ validationCellType <- function(Y, pheno, modelFix, modelBatch=NULL,
     rownames(coefEsts) <- rownames(Y)
     colnames(coefEsts) <- names(fitCoef)
     degFree <- nObserved - nClusters - sizeModel + 1
-
+    
     ## Get P values corresponding to F statistics
     Pval <- 1-pf(Fstat, sizeModel, degFree)
-
-    out <- list(coefEsts=coefEsts, coefVcovs=coefVcovs, modelFix=modelFix,
+    
+    out <- list(coefEsts=coefEsts, coefVcovs=coefVcovs, modelFix=modelFix, 
                 modelBatch=modelBatch,
-                sigmaIcept=sigmaIcept, sigmaResid=sigmaResid,
+                sigmaIcept=sigmaIcept, sigmaResid=sigmaResid, 
                 L.forFstat=L.forFstat, Pval=Pval,
-                orderFstat=order(-Fstat), Fstat=Fstat, nClusters=nClusters,
+                orderFstat=order(-Fstat), Fstat=Fstat, nClusters=nClusters, 
                 nObserved=nObserved,
                 degFree=degFree)
-
+    
     out
 }

--- a/R/estimateCellCounts2.R
+++ b/R/estimateCellCounts2.R
@@ -337,7 +337,7 @@ estimateCellCounts2 <- function(rgSet, compositeCellType = "Blood",
                         'cellTypes' for your estimation.\n",
                         width = 80, prefix = " ", initial = ""))
     if (compositeCellType == "CordBloodCombined")
-        platform<="450k"
+        platform <- "450k"
     referencePkg <- sprintf("FlowSorted.%s.%s", compositeCellType, platform)
     subverbose <- max(as.integer(verbose) - 1L, 0L)
     if (!is.null(referenceset)){

--- a/R/projectCellType_CP.R
+++ b/R/projectCellType_CP.R
@@ -2,10 +2,8 @@
 #'  
 #' @description    This function predicts the underlying cellular composition of
 #' heterogeneous tissue  types (i.e., WB) using the constrained projection 
-#' procedure described by 
-#' \href{https://dx.doi.org/10.1186/s12859-016-0943-7}{Houseman et al. 2012}. 
-#' This is equivalent to the internal projectCellType function in minfi,
-#' \href{https://dx.doi.org/10.1186/gb-2014-15-2-r31}{Jaffe et al. 2014}. We 
+#' procedure described by Houseman et al., (2012). 
+#' This is equivalent to the internal projectCellType function in minfi. We 
 #' recommend this function only for advanced users. Please preprocess your 
 #' dataset filtering potential bad quality samples.  
 #'
@@ -67,11 +65,11 @@
 #'
 #' @param
 #' coefWBC A J x K projection matrix;, i.e., within-cell type mean methylation
-#'     matrix across J L-DMRs and K number of cell types
+#'     matrix across J DMLs and K many cell types
 #'
 #' @param	
 #' contrastWBC Contrast for cell composition predictions set to NULL by   
-#'               default. The user should not modify this 
+#'               default. The user needn't modify this 
 #'
 #' @param
 #' nonnegative Should cell predictions be nonnegative.  Defaults to TRUE

--- a/man/FlowSorted.Blood.EPIC.Rd
+++ b/man/FlowSorted.Blood.EPIC.Rd
@@ -4,13 +4,11 @@
 \name{FlowSorted.Blood.EPIC}
 \alias{FlowSorted.Blood.EPIC}
 \title{FlowSorted.Blood.EPIC}
-\format{
-A class: RGChannelSet, dimensions: 1051815 49
-}
+\format{A class: RGChannelSet, dimensions: 1051815 49}
 \source{
+\url{https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE110554}
 The FlowSorted.Blood.EPIC object is based in samples assayed
-by Brock Christensen and colleagues; Salas et al. 2018. 
-\href{https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE110554}{GSE110554}
+by Brock Christensen and colleagues; manuscript submmited.
 }
 \usage{
 FlowSorted.Blood.EPIC
@@ -19,10 +17,9 @@ FlowSorted.Blood.EPIC
 Illumina Human Methylation data from EPIC on immunomagnetic sorted adult 
 blood cell populations. The FlowSorted.Blood.EPIC package contains Illumina
 HumanMethylationEPIC (\dQuote{EPIC})) DNA methylation microarray data
-from the immunomethylomics group  
-\href{https://dx.doi.org/10.1186/s13059-018-1448-7}{(Salas et al. 2018)}, 
-consisting of 37 magnetic sorted blood cell references and 12 samples, 
-formatted as an RGChannelSet object for  integration and normalization using
+from the immunomethylomics group (manuscript submitted), consisting of 37 
+magnetic sorted blood cell references and 12 samples, formatted as an
+RGChannelSet object for  integration and normalization using
 most of the existing Bioconductor packages.
 
 This package contains data similar to the FlowSorted.Blood.450k
@@ -62,14 +59,15 @@ References \enumerate{
 \item LA Salas et al. (2018). \emph{An optimized library for 
 reference-based deconvolution of whole-blood biospecimens assayed using the 
 Illumina HumanMethylationEPIC BeadArray}. Genome Biology 19, 64. doi:
-\href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}.
+10.1186/s13059-018-1448-7.
 \item DC Koestler et al. (2016). \emph{Improving cell mixture deconvolution 
 by identifying optimal DNA methylation libraries (IDOL)}. BMC bioinformatics.
-17, 120. doi:\href{https://dx.doi.org/10.1186/s12859-016-0943-7}{10.1186/s12859-016-0943-7}.
+17, 120. doi: 10.1186/s12859-016-0943-7.
 \item EA Houseman et al. (2012) \emph{DNA methylation arrays as surrogate
 measures of cell mixture distribution}. BMC Bioinformatics 13, 86.
-doi:\href{https://dx.doi.org/10.1186/s12859-016-0943-7}{10.1186/1471-2105-13-86}.
-\item \pkg{minfi} package, tools for analyzing DNA methylation microarrays
+doi:10.1186/1471-2105-13-86.
+\item \pkg{minfi} package for tools for estimating cell type
+composition in blood using these data
 }
 }
 \keyword{datasets}

--- a/man/IDOLOptimizedCpGs.Rd
+++ b/man/IDOLOptimizedCpGs.Rd
@@ -4,12 +4,10 @@
 \name{IDOLOptimizedCpGs}
 \alias{IDOLOptimizedCpGs}
 \title{IDOL Optimized CpGs for adult blood DNA methylation deconvolution EPIC}
-\format{
-An object of class "character" of length 450.
+\format{An object of class "character" of length 450.
 
         The format is:
-        chr [1:450] "cg08769189" "cg07661835" "cg00219921" "cg13468685" ...
-}
+        chr [1:450] "cg08769189" "cg07661835" "cg00219921" "cg13468685" ...}
 \usage{
 IDOLOptimizedCpGs
 }
@@ -27,11 +25,10 @@ This object is a vector of length 450 consisting of the names of the IDOL
 LA Salas et al. (2018). \emph{An optimized library for 
 reference-based deconvolution of whole-blood biospecimens assayed using the 
 Illumina HumanMethylationEPIC BeadArray}. Genome Biology 19, 64. doi:
-\href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}
+10.1186/s13059-018-1448-7.
 
 DC Koestler et al. (2016). \emph{Improving cell mixture 
 deconvolution by identifying optimal DNA methylation libraries (IDOL)}. 
-BMC bioinformatics. 17, 120. doi: 
-\href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}.
+BMC bioinformatics. 17, 120. doi: 10.1186/s12859-016-0943-7.
 }
 \keyword{datasets}

--- a/man/IDOLOptimizedCpGs.compTable.Rd
+++ b/man/IDOLOptimizedCpGs.compTable.Rd
@@ -4,12 +4,10 @@
 \name{IDOLOptimizedCpGs.compTable}
 \alias{IDOLOptimizedCpGs.compTable}
 \title{IDOL Optimized CpGs matrix for adult blood DNA methylation deconvolution EPIC}
-\format{
-An object of class "matrix" of dimensions 450 x 6.
+\format{An object of class "matrix" of dimensions 450 x 6.
 
         The format is:
-        num [1:450, 1:6] 0.197  0.105  0.135  0.654  0.246 ...
-}
+        num [1:450, 1:6] 0.197  0.105  0.135  0.654  0.246 ...}
 \usage{
 IDOLOptimizedCpGs.compTable
 }
@@ -29,11 +27,10 @@ This object is a matrix of dimensions 450 x 6 consisting of the average
 LA Salas et al. (2018). \emph{An optimized library for 
 reference-based deconvolution of whole-blood biospecimens assayed using the 
 Illumina HumanMethylationEPIC BeadArray}. Genome Biology 19, 64. doi:
-\href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}
+10.1186/s13059-018-1448-7.
 
 DC Koestler et al. (2016). \emph{Improving cell mixture 
 deconvolution by identifying optimal DNA methylation libraries (IDOL)}. 
-BMC bioinformatics. 17, 120. doi: 
-\href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}.
+BMC bioinformatics. 17, 120. doi: 10.1186/s12859-016-0943-7.
 }
 \keyword{datasets}

--- a/man/IDOLOptimizedCpGs450klegacy.Rd
+++ b/man/IDOLOptimizedCpGs450klegacy.Rd
@@ -4,12 +4,10 @@
 \name{IDOLOptimizedCpGs450klegacy}
 \alias{IDOLOptimizedCpGs450klegacy}
 \title{IDOL Optimized CpGs for adult blood DNA methylation deconvolution EPIC}
-\format{
-An object of class "character" of length 350.
+\format{An object of class "character" of length 350.
 
         The format is:
-        chr [1:350] "cg14232368" "cg15087459" "cg20538211" "cg11944101" ...
-}
+        chr [1:350] "cg14232368" "cg15087459" "cg20538211" "cg11944101" ...}
 \usage{
 IDOLOptimizedCpGs450klegacy
 }
@@ -28,11 +26,10 @@ This object is a vector of length 350 consisting of the names of the IDOL
 LA Salas et al. (2018). \emph{An optimized library for 
 reference-based deconvolution of whole-blood biospecimens assayed using the 
 Illumina HumanMethylationEPIC BeadArray}. Genome Biology 19, 64. doi:
-\href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}
+10.1186/s13059-018-1448-7.
 
-DC Koestler et al. (2016). \emph{Improving cell mixture 
+D Koestler et al. (2016). \emph{Improving cell mixture 
 deconvolution by identifying optimal DNA methylation libraries (IDOL)}. 
-BMC bioinformatics. 17, 120. doi: 
-\href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}.
+BMC bioinformatics. 17, 120. doi: 10.1186/s12859-016-0943-7.
 }
 \keyword{datasets}

--- a/man/IDOLOptimizedCpGs450klegacy.compTable.Rd
+++ b/man/IDOLOptimizedCpGs450klegacy.compTable.Rd
@@ -4,12 +4,10 @@
 \name{IDOLOptimizedCpGs450klegacy.compTable}
 \alias{IDOLOptimizedCpGs450klegacy.compTable}
 \title{IDOL Optimized CpGs matrix for adult blood DNA methylation deconvolution EPIC}
-\format{
-An object of class "matrix" of dimensions 450 x 6.
+\format{An object of class "matrix" of dimensions 450 x 6.
 
         The format is:
-        num [1:350, 1:6] 0.904  0.122  0.633  0.841  0.135 ...
-}
+        num [1:350, 1:6] 0.904  0.122  0.633  0.841  0.135 ...}
 \usage{
 IDOLOptimizedCpGs450klegacy.compTable
 }
@@ -30,11 +28,10 @@ This object is a matrix of dimensions 350 x 6 consisting of the average
 LA Salas et al. (2018). \emph{An optimized library for 
 reference-based deconvolution of whole-blood biospecimens assayed using the 
 Illumina HumanMethylationEPIC BeadArray}. Genome Biology 19, 64. doi:
-\href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}
+10.1186/s13059-018-1448-7.
 
-DC Koestler et al. (2016). \emph{Improving cell mixture 
+D Koestler et al. (2016). \emph{Improving cell mixture 
 deconvolution by identifying optimal DNA methylation libraries (IDOL)}. 
-BMC bioinformatics. 17, 120. doi: 
-\href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}.
+BMC bioinformatics. 17, 120. doi: 10.1186/s12859-016-0943-7.
 }
 \keyword{datasets}

--- a/man/estimateCellCounts2.Rd
+++ b/man/estimateCellCounts2.Rd
@@ -264,37 +264,33 @@ head(countsEPIC$counts)
 LA Salas et al. (2018). \emph{An optimized library for 
 reference-based deconvolution of whole-blood biospecimens assayed using the 
 Illumina HumanMethylationEPIC BeadArray}. Genome Biology 19, 64. doi:
-\href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}
+10.1186/s13059-018-1448-7.
 
 DC Koestler et al. (2016). \emph{Improving cell mixture 
 deconvolution by identifying optimal DNA methylation libraries (IDOL)}. 
-BMC bioinformatics. 17, 120. doi: 
-\href{https://dx.doi.org/10.1186/s13059-018-1448-7}{10.1186/s13059-018-1448-7}.
+BMC bioinformatics. 17, 120. doi: 10.1186/s12859-016-0943-7.
 
 EA Houseman, et al.(2012)  \emph{DNA methylation arrays as 
 surrogate measures of cell mixture distribution}. BMC bioinformatics  13:86. 
-doi:\href{https://dx.doi.org/10.1186/s12859-016-0943-7}{10.1186/1471-2105-13-86}.
+doi:10.1186/1471-2105-13-86.
 
 AE Jaffe and RA Irizarry.(2014) \emph{Accounting for cellular 
 heterogeneity is critical in epigenome-wide association studies}. 
-Genome Biology  15:R31. doi:
-\href{https://dx.doi.org/10.1186/gb-2014-15-2-r31}{10.1186/gb-2014-15-2-r31}.
+Genome Biology  15:R31. doi:10.1186/gb-2014-15-2-r31.
 
 K Gervin, LA Salas et al. (2019) \emph{Systematic evaluation and 
 validation of references and library selection methods for deconvolution of 
 cord blood DNA methylation data}. Clin Epigenetics 11,125. doi:
-\href{https://dx.doi.org/10.1186/s13148-019-0717-y}{10.1186/s13148-019-0717-y}.
+10.1186/s13148-019-0717-y
 
 KM Bakulski, et al. (2016) \emph{DNA methylation of cord blood 
 cell types: Applications for mixed cell birth studies}. Epigenetics 11:5. 
-doi:\href{https://dx.doi.org/10.1080/15592294.2016.1161875}{10.1080/15592294.2016.1161875}.
+doi:10.1080/15592294.2016.1161875.
 
 AJ Titus, et al. (2017). \emph{Cell-type deconvolution from DNA 
 methylation: a review of recent applications}. Hum Mol Genet 26: R216-R224.
-doi:\href{https://dx.doi.org/10.1093/hmg/ddx275}{10.1093/hmg/ddx275}
 
 AE Teschendorff, et al. (2017). \emph{A comparison of 
 reference-based algorithms for correcting cell-type heterogeneity in 
-Epigenome-Wide Association Studies}. BMC Bioinformatics 18: 105. doi:
-\href{https://dx.doi.org/10.1186/s12859-017-1511-5}{10.1186/s12859-017-1511-5}
+Epigenome-Wide Association Studies}. BMC Bioinformatics 18: 105.
 }

--- a/man/projectCellType_CP.Rd
+++ b/man/projectCellType_CP.Rd
@@ -33,10 +33,8 @@ of the N subjects contained in the Target Set.
 \description{
 This function predicts the underlying cellular composition of
 heterogeneous tissue  types (i.e., WB) using the constrained projection 
-procedure described by 
-\href{https://dx.doi.org/10.1186/s12859-016-0943-7}{Houseman et al. 2012}. 
-This is equivalent to the internal projectCellType function in minfi,
-\href{https://dx.doi.org/10.1186/gb-2014-15-2-r31}{Jaffe et al. 2014}. We 
+procedure described by Houseman et al., (2012). 
+This is equivalent to the internal projectCellType function in minfi. We 
 recommend this function only for advanced users. Please preprocess your 
 dataset filtering potential bad quality samples.
 }


### PR DESCRIPTION
This PR fix a typo when setting the default platform for `CordBloodCombined` when not setting `referenceset` (detected because of #6 ).
https://github.com/immunomethylomics/FlowSorted.Blood.EPIC/blob/2a11906c0d4660a9411ebf7d45062d9e730ea00f/R/estimateCellCounts2.R#L343-L344

This PR also trimmed all trailing spaces (not intentional though).